### PR TITLE
fix: bump to latest version of docker build to address provenance issue

### DIFF
--- a/.github/workflows/dagster.yml
+++ b/.github/workflows/dagster.yml
@@ -79,7 +79,7 @@ jobs:
           ssh-add - <<< "${{ secrets.SSH_KEY }}"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v2.4.1
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0.2.1
@@ -97,7 +97,7 @@ jobs:
         run: echo ::set-output name=IMAGE_FULLNAME::eu.gcr.io/${{ inputs.gcp_project }}/${{ inputs.image_name }}:${GITHUB_REF#refs/tags/}
 
       - name: Build docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4.0.0
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         with:
@@ -120,7 +120,7 @@ jobs:
           for i in $(seq 1 10); do /tmp/grpc_health_probe -addr=localhost:8080 && s=0 && break || s=$? && sleep 2; done; (docker logs test_container && exit $s)
 
       - name: Push docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4.0.0
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         with:
@@ -133,6 +133,7 @@ jobs:
             ${{ github.ref == format('refs/heads/{0}', inputs.branch) && format('eu.gcr.io/{0}/{1}:stage', inputs.gcp_project, inputs.image_name) || '' }}
             ${{ startsWith(github.ref, 'refs/tags/') && steps.get_tag.outputs.IMAGE_FULLNAME || '' }}
             ${{ startsWith(github.ref, 'refs/tags/') && format('eu.gcr.io/{0}/{1}:prod', inputs.gcp_project, inputs.image_name) || '' }}
+          provenance: false # Image attestations not supported in GCR: https://github.com/docker/buildx/issues/1533
 
       - uses: google-github-actions/get-gke-credentials@v0.3.0
         with:

--- a/.github/workflows/dagster.yml
+++ b/.github/workflows/dagster.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           task: 'remove'
           helm: helm3
-          repository: "https://dagster-io.github.io/helm"
+          repository: 'https://dagster-io.github.io/helm'
           chart: 'dagster'
           release: "${{ format('{0}-pr-{1}', inputs.image_name, github.event.number) }}"
           namespace: 'dagster'
@@ -79,7 +79,7 @@ jobs:
           ssh-add - <<< "${{ secrets.SSH_KEY }}"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0.2.1
@@ -97,7 +97,7 @@ jobs:
         run: echo ::set-output name=IMAGE_FULLNAME::eu.gcr.io/${{ inputs.gcp_project }}/${{ inputs.image_name }}:${GITHUB_REF#refs/tags/}
 
       - name: Build docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         with:
@@ -120,7 +120,7 @@ jobs:
           for i in $(seq 1 10); do /tmp/grpc_health_probe -addr=localhost:8080 && s=0 && break || s=$? && sleep 2; done; (docker logs test_container && exit $s)
 
       - name: Push docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         with:
@@ -150,7 +150,7 @@ jobs:
         uses: AndreaGiardini/helm@master # Should be replaced with deliverybot/helm@v1 when https://github.com/deliverybot/helm/issues/66 is fixed
         with:
           helm: helm3
-          repository: "https://dagster-io.github.io/helm"
+          repository: 'https://dagster-io.github.io/helm'
           chart: 'dagster'
           release: "${{ format('{0}-pr-{1}', inputs.image_name, github.event.number) }}"
           namespace: 'dagster'


### PR DESCRIPTION
https://github.com/docker/build-push-action/pull/781

Addresses issue with GCR not supporting attestations. Ref: https://github.com/docker/buildx/issues/1533
Looks like we'll need to move to artifact registry before going to `docker/build-push-action@v4` or explicitly set `provenance: false` in v4.