### PR TITLE
add commit sha tag to images when pushing to container registry

### DIFF
--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -80,6 +80,7 @@ jobs:
           push: true
           ssh: default
           tags: |
+            ${{ format('eu.gcr.io/{0}/{1}:{2}', inputs.gcp_project, inputs.image_name, github.sha) }}
             ${{ github.event_name == 'pull_request' && format('eu.gcr.io/{0}/{1}:pr-{2}', inputs.gcp_project, inputs.image_name, github.event.number) || '' }}
             ${{ github.ref == format('refs/heads/{0}', inputs.branch) && format('eu.gcr.io/{0}/{1}:latest', inputs.gcp_project, inputs.image_name) || '' }}
             ${{ github.ref == format('refs/heads/{0}', inputs.branch) && format('eu.gcr.io/{0}/{1}:stage', inputs.gcp_project, inputs.image_name) || '' }}


### PR DESCRIPTION
This is needed because github actions in some repos (see [labelbox-webhooks](https://github.com/20treeAI/labelbox-webhooks/blob/main/.github/workflows/push_to_prod.yml#L23)) expect images to be tagged with the commit sha, so that they can pull the latest image and tag it appropriately for a release. 