### PR TITLE
adding reusable yarn workflow and cloudrun/sentry optionals

### DIFF
--- a/.github/workflows/cloudrun_deploy_optional_sentry.yml
+++ b/.github/workflows/cloudrun_deploy_optional_sentry.yml
@@ -52,24 +52,26 @@ jobs:
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Cloud SDK
-        if: ${{ inputs.image_tag }}
-        uses: google-github-actions/setup-gcloud@v1.1.0
+      # actions/checkout MUST come before auth, ref: github.com/google-github-actions/auth
+      - uses: 'actions/checkout@v3'
+
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
         with:
           credentials_json: '${{ secrets.CLOUDRUN_DEPLOYER_SERVICEACCOUNT_KEY }}'
 
-      - name: Tag prod Docker image
+      - name: Tag Docker image
         if: ${{ inputs.image_tag }}
         run: gcloud container images add-tag '${{ inputs.image_name }}:${{ github.sha }}' '${{ inputs.image_name }}:${{ inputs.image_tag }}'
 
       - name: Deploy to Cloud Run
-        uses: google-github-actions/deploy-cloudrun@v1.0.0
+        uses: google-github-actions/deploy-cloudrun@v1
         with:
           service: ${{ inputs.service_name }}
           region: ${{ inputs.region }}
           project_id: ${{inputs.gcp_project }}
           image: 'eu.gcr.io/${{ inputs.gcp_project }}/${{ inputs.image_name }}:${{ github.sha }}'
-          credentials: ${{ secrets.CLOUDRUN_DEPLOYER_SERVICEACCOUNT_KEY }}
 
       - name: Create Sentry release
         if: ${{ inputs.create_sentry_release }}

--- a/.github/workflows/cloudrun_deploy_optional_sentry.yml
+++ b/.github/workflows/cloudrun_deploy_optional_sentry.yml
@@ -1,8 +1,17 @@
-name: Deploy to Cloud Run and Create Sentry Release
+name: Deploy to Google Cloud Run and Create Sentry Release
 
 on:
   workflow_call:
     inputs:
+      gcp_project:
+        description: 'GCP project where GCR is located for storing built Docker images'
+        required: true
+        type: string
+      region:
+        description: 'Region to deploy cloudrun app and docker image'
+        required: false
+        default: 'europe-west4'
+        type: string
       image_name:
         description: 'Docker image name'
         required: true
@@ -10,10 +19,6 @@ on:
       image_tag:
         description: 'Name of tag for docker image'
         required: false
-        type: string
-      gcp_project:
-        description: 'GCP project where GCR is located for storing built Docker images'
-        required: true
         type: string
       cloud_run:
         description: 'Whether or not to deploy to Google Cloud Run'
@@ -61,7 +66,7 @@ jobs:
         uses: google-github-actions/deploy-cloudrun@v1.0.0
         with:
           service: ${{ inputs.service_name }}
-          region: europe-west4
+          region: ${{ inputs.region }}
           project_id: ${{inputs.gcp_project }}
           image: 'eu.gcr.io/${{ inputs.gcp_project }}/${{ inputs.image_name }}:${{ github.sha }}'
           credentials: ${{ secrets.CLOUDRUN_DEPLOYER_SERVICEACCOUNT_KEY }}

--- a/.github/workflows/cloudrun_deploy_optional_sentry.yml
+++ b/.github/workflows/cloudrun_deploy_optional_sentry.yml
@@ -46,6 +46,7 @@ jobs:
           credentials: ${{ secrets.CLOUDRUN_DEPLOYER_SERVICEACCOUNT_KEY }}
 
       - name: Create Sentry release
+       if: ${{ inputs.create_sentry_release }}
         uses: getsentry/action-release@v1
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/cloudrun_deploy_optional_sentry.yml
+++ b/.github/workflows/cloudrun_deploy_optional_sentry.yml
@@ -50,6 +50,8 @@ jobs:
       - name: Set up Cloud SDK
         if: ${{ inputs.image_tag }}
         uses: google-github-actions/setup-gcloud@v1.1.0
+        with:
+          credentials_json: '${{ secrets.CLOUDRUN_DEPLOYER_SERVICEACCOUNT_KEY }}'
 
       - name: Tag prod Docker image
         if: ${{ inputs.image_tag }}

--- a/.github/workflows/cloudrun_deploy_optional_sentry.yml
+++ b/.github/workflows/cloudrun_deploy_optional_sentry.yml
@@ -1,0 +1,56 @@
+name: Deploy to Cloud Run and Create Sentry Release
+
+on:
+  workflow_call:
+    inputs:
+      image_name:
+        description: 'Docker image name'
+        required: true
+        type: string
+      gcp_project:
+        description: 'GCP project where GCR is located for storing built Docker images'
+        required: true
+        type: string
+      cloud_run:
+        description: 'Whether or not to deploy to Google Cloud Run'
+        default: true
+        type: boolean
+      service_name:
+        description: 'Name of service to update in Cloud Run'
+        required: true
+        type: string
+      sentry_release:
+        description: 'Whether or not to create a Sentry release for the this project'
+        required: false
+        default: false 
+        type: boolean
+      environment:
+        description: 'Environment to deploy to: stage or prod'
+        required: true
+        default: 'stage'
+        type: string
+
+jobs:
+  deploy:
+    name: Deploy to ${{ inputs.environment }}
+    environment: ${{ inputs.environment }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to Cloud Run
+        uses: google-github-actions/deploy-cloudrun@v0.10.1
+        with:
+          service: ${{ inputs.service_name }}
+          region: europe-west4
+          image: 'eu.gcr.io/${{ inputs.gcp_project }}/${{ inputs.image_name }}:${{ github.sha }}'
+          credentials: ${{ secrets.CLOUDRUN_DEPLOYER_SERVICEACCOUNT_KEY }}
+
+      - name: Create Sentry release
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        with:
+          environment: ${{ inputs.environment }}
+          sourcemaps: './build'

--- a/.github/workflows/cloudrun_deploy_optional_sentry.yml
+++ b/.github/workflows/cloudrun_deploy_optional_sentry.yml
@@ -55,6 +55,7 @@ jobs:
       # actions/checkout MUST come before auth, ref: github.com/google-github-actions/auth
       - uses: 'actions/checkout@v3'
 
+      # required for gcloud docker command and deployment to Cloud Run
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@v1'
@@ -73,6 +74,7 @@ jobs:
           project_id: ${{inputs.gcp_project }}
           image: 'eu.gcr.io/${{ inputs.gcp_project }}/${{ inputs.image_name }}:${{ github.sha }}'
 
+      # this is optional
       - name: Create Sentry release
         if: ${{ inputs.create_sentry_release }}
         uses: getsentry/action-release@v1.3.1

--- a/.github/workflows/cloudrun_deploy_optional_sentry.yml
+++ b/.github/workflows/cloudrun_deploy_optional_sentry.yml
@@ -29,6 +29,13 @@ on:
         required: true
         default: 'stage'
         type: string
+    secrets:
+      CLOUDRUN_DEPLOYER_SERVICEACCOUNT_KEY:
+        description: 'Service Account key for the cloud run deployer'
+        required: true
+      SENTRY_AUTH_TOKEN:
+        description: 'Token for sentry auth'
+        required: false
 
 jobs:
   deploy:

--- a/.github/workflows/cloudrun_deploy_optional_sentry.yml
+++ b/.github/workflows/cloudrun_deploy_optional_sentry.yml
@@ -62,6 +62,7 @@ jobs:
         with:
           service: ${{ inputs.service_name }}
           region: europe-west4
+          project_id: ${{inputs.gcp_project }}
           image: 'eu.gcr.io/${{ inputs.gcp_project }}/${{ inputs.image_name }}:${{ github.sha }}'
           credentials: ${{ secrets.CLOUDRUN_DEPLOYER_SERVICEACCOUNT_KEY }}
 

--- a/.github/workflows/cloudrun_deploy_optional_sentry.yml
+++ b/.github/workflows/cloudrun_deploy_optional_sentry.yml
@@ -7,6 +7,10 @@ on:
         description: 'Docker image name'
         required: true
         type: string
+      image_tag:
+        description: 'Name of tag for docker image'
+        required: false
+        type: string
       gcp_project:
         description: 'GCP project where GCR is located for storing built Docker images'
         required: true
@@ -42,10 +46,17 @@ jobs:
     name: Deploy to ${{ inputs.environment }}
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
-    needs: build
     steps:
+      - name: Set up Cloud SDK
+        if: ${{ inputs.image_tag }}
+        uses: google-github-actions/setup-gcloud@v1.1.0
+
+      - name: Tag prod Docker image
+        if: ${{ inputs.image_tag }}
+        run: gcloud container images add-tag '${{ inputs.image_name }}:${{ github.sha }}' '${{ inputs.image_name }}:${{ inputs.image_tag }}'
+
       - name: Deploy to Cloud Run
-        uses: google-github-actions/deploy-cloudrun@v0.10.1
+        uses: google-github-actions/deploy-cloudrun@v1.0.0
         with:
           service: ${{ inputs.service_name }}
           region: europe-west4
@@ -54,7 +65,7 @@ jobs:
 
       - name: Create Sentry release
         if: ${{ inputs.create_sentry_release }}
-        uses: getsentry/action-release@v1
+        uses: getsentry/action-release@v1.3.1
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}

--- a/.github/workflows/cloudrun_deploy_optional_sentry.yml
+++ b/.github/workflows/cloudrun_deploy_optional_sentry.yml
@@ -53,7 +53,7 @@ jobs:
           credentials: ${{ secrets.CLOUDRUN_DEPLOYER_SERVICEACCOUNT_KEY }}
 
       - name: Create Sentry release
-       if: ${{ inputs.create_sentry_release }}
+        if: ${{ inputs.create_sentry_release }}
         uses: getsentry/action-release@v1
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/cloudrun_deploy_optional_sentry.yml
+++ b/.github/workflows/cloudrun_deploy_optional_sentry.yml
@@ -20,10 +20,6 @@ on:
         description: 'Name of tag for docker image'
         required: false
         type: string
-      cloud_run:
-        description: 'Whether or not to deploy to Google Cloud Run'
-        default: true
-        type: boolean
       service_name:
         description: 'Name of service to update in Cloud Run'
         required: true

--- a/.github/workflows/dagster.yml
+++ b/.github/workflows/dagster.yml
@@ -16,6 +16,7 @@ on:
       gcp_project:
         description: 'GCP project where GCR is located for storing built Docker images'
         required: true
+        default: ''
         type: string
       cluster_name:
         description: 'K8s cluster name on which Dagster workflow is deployed to'

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -88,6 +88,9 @@ jobs:
           tags: test-image
           ssh: default
 
+      - name: Configure Docker
+        run: gcloud auth configure-docker
+
       - name: Push docker image
         uses: docker/build-push-action@v4.0.0
         env:

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -1,5 +1,5 @@
 ---
-name: docker workflow - build and push docker images to GCS
+name: docker workflow - build and push docker images to GCR
 
 on:
   workflow_call:
@@ -10,11 +10,12 @@ on:
         type: string
       branch:
         description: 'Git branch used for tagging incremental builds of the Docker image'
-        default: 'master'
+        default: 'main'
         required: false
         type: string
       gcp_project:
         description: 'GCP project where GCR is located for storing built Docker images'
+        default: ''
         required: true
         type: string
     secrets:

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -5,11 +5,11 @@ on:
   workflow_call:
     inputs:
       artifacts_object_name:
-        description: ''
+        description: 'Name of the artifacts object to pass to docker build job'
         required: false
         type: string
       artifacts_path:
-        description: ''
+        description: 'Path to use for the artifacts object. Defaults to build/'
         default: 'build/'
         required: false
         type: string
@@ -70,7 +70,7 @@ jobs:
           service_account_key: ${{ secrets.GCR_RW_SERVICEACCOUNT_KEY }}
           export_default_credentials: true
 
-      - name: Configure Docker
+      - name: Use glcoud CLI to configure-docker auth
         run: gcloud auth configure-docker
 
       - if: ${{ startsWith(github.ref, 'refs/tags/') }}
@@ -87,6 +87,7 @@ jobs:
           load: true
           tags: test-image
           ssh: default
+          provenance: false
 
       - name: Push docker image
         uses: docker/build-push-action@v4.0.0

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -88,9 +88,6 @@ jobs:
           tags: test-image
           ssh: default
 
-      - name: Configure Docker
-        run: gcloud auth configure-docker
-
       - name: Push docker image
         uses: docker/build-push-action@v4.0.0
         env:

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -4,6 +4,15 @@ name: docker workflow - build and push docker images to GCR
 on:
   workflow_call:
     inputs:
+      artifacts_object_name:
+        description: ''
+        required: false
+        type: string
+      artifacts_path:
+        description: ''
+        default: 'build/'
+        required: false
+        type: string
       image_name:
         description: 'Docker image name'
         required: true
@@ -43,6 +52,13 @@ jobs:
           ssh-keyscan github.com >> ~/.ssh/known_hosts
           ssh-agent -a $SSH_AUTH_SOCK > /dev/null
           ssh-add - <<< "${{ secrets.SSH_KEY }}"
+
+      - if: ${{ inputs.artifacts_object_name }}
+        name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.artifacts_object_name }}
+          path: ${{ inputs.artifacts_path }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2.4.1

--- a/.github/workflows/yarn_build_test.yml
+++ b/.github/workflows/yarn_build_test.yml
@@ -1,0 +1,46 @@
+name: yarn - build and test
+
+# https://docs.github.com/en/actions/using-workflows/reusing-workflows#creating-a-reusable-workflow
+on:
+  workflow_call:
+
+jobs:
+  build:
+    name: Build and Test with Yarn
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v3
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-v2-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-v2-
+
+      - name: Install dependencies
+        uses: borales/actions-yarn@v3.0.0
+        with:
+          cmd: install # will run `yarn install` command
+
+      - name: Build application
+        uses: borales/actions-yarn@v3.0.0
+        with:
+          cmd: build # will run `yarn build` command
+
+      - name: Test application
+        uses: borales/actions-yarn@v3.0.0
+        with:
+          cmd: test # will run `yarn test` command
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-artifacts
+          path: build/
+          retention-days: 1

--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ TODO: [Example call to cloudrun workflow](./examples/)
 | name           | description                                                       | type    | default        | required | 
 |:--------------:|:------------------------------------------------------------------|:-------:|:---------------|:--------:|
 | image_name     | Docker image name                                                 | string  | None           | true     |
+| image_tag      | Name of Tag for Docker image                                      | string  | None           | false    |
 | gcp_project    | GCP project where GCR is located for storing built Docker images  | string  | None           | true     |
-| cluster_name   | K8s cluster name on which Dagster workflow is deployed to         | string  | None           | true     |
 | service_name   | Name of service to update in Cloud Run                            | string  | None           | true     |
-| sentry_release | Whether or not to create a Sentry release for the this project    | boolean | false          | true     |
+| sentry_release | Whether or not to create a Sentry release for the this project    | boolean | false          | false    |
 | environment    | Environment to deploy to: stage or prod                           | string  | None           | true     |
 
 #### Input Secrets

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ These are the github repo secrets you must create ahead of time
 </details>
 
 
-## Docker Build and Push
+## Docker Build and Push (To GCR)
 This [workflow](./.github/workflows/docker_build_push.yml) will build and push a docker image. You can optionally pass in artifacts from previous jobs with the `artifacts_object_name` and `artifacts_path` input variables, to ensure the docker image gets built with context from a previous job.
 
 [Example call to Docker Build and Push workflow without artifacts](./examples/docker_build_push.yml)
@@ -56,7 +56,7 @@ These are the github repo secrets you must create ahead of time
 </details>
 
 
-## Deploy to Cloud Run (Optional: Create Sentry Release)
+## Deploy to Google Cloud Run (Optional: Create Sentry Release)
 This [workflow](./.github/workflows/) will deploy a docker image to a Cloud Run service and optionally create a sentry release.
 
 TODO: [Example call to cloudrun workflow](./examples/)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ TODO: [Example call to Docker Build and Push workflow](./examples/)
 | image_name   | Docker image name                                                  | string | None        | true     |
 | branch       | Git branch used for tagging incremental builds of the Docker image | string | master      | true     |
 | gcp_project  | GCP project where GCR is located for storing built Docker images   | string | None        | true     |
-| cluster_name | K8s cluster name on which Dagster workflow is deployed to          | string | None        | true     |
 
 #### Input Secrets
 These are the github repo secrets you must create ahead of time

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # github-workflows
 
-This repo contains [reusable workflows](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows) for Github Ections.
+This repo contains [reusable workflows](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows) for Github Actions.
 
 ## Dagster
 This [workflow](./.github/workflows/dagster.yml) will build a docker image and then test it before pushing it.

--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ TODO: [Example call to cloudrun workflow](./examples/)
 #### Input Secrets
 These are the github repo secrets you must create ahead of time
 
-| name                      | description                                                | required | 
-|:-------------------------:|:-----------------------------------------------------------|:--------:|
-| SSH_KEY                   | SSH key used to access private repos during the build      | true     |
-| GCR_RW_SERVICEACCOUNT_KEY | GCR service account credentials to push/pull Docker images | true     |
+| name                                | description                                                | required  | 
+|:-----------------------------------:|:-----------------------------------------------------------|:---------:|
+| CLOUDRUN_DEPLOYER_SERVICEACCOUNT_KEY| GCP Service Account key for the cloud run deployer         | true      |
+| SENTRY_AUTH_TOKEN                   | Token for sentry authentication                            | false     |
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,89 @@
 # github-workflows
 
-This repo contains [reusable workflows](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows) for Github.
+This repo contains [reusable workflows](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows) for Github Ections.
+
+## Dagster
+This [workflow](./.github/workflows/dagster.yml) will build a docker image and then test it before pushing it.
+
+[Example call to dagster workflow](./examples/dagster.yml)
+
+<details>
+  <summary>Workflow Input Variables</summary>
+
+| name         | description                                                        | type   | default        | required | 
+|:------------:|:-------------------------------------------------------------------|:------:|:---------------|:--------:|
+| image_name   | Docker image name                                                  | string | None           | true     |
+| branch       | Git branch used for tagging incremental builds of the Docker image | string | master         | true     |
+| gcp_project  | GCP project where GCR is located for storing built Docker images   | string | None           | true     |
+| cluster_name | K8s cluster name on which Dagster workflow is deployed to          | string | None           | true     |
+
+#### Input Secrets
+These are the github repo secrets you must create ahead of time
+
+| name                      | description                                                | required | 
+|:-------------------------:|:-----------------------------------------------------------|:--------:|
+| SSH_KEY                   | SSH key used to access private repos during the build      | true     |
+| GCR_RW_SERVICEACCOUNT_KEY | GCR service account credentials to push/pull Docker images | true     |
+
+</details>
+
+
+## Docker Build and Push
+This [workflow](./.github/workflows/docker_build_push.yml) will build and push a docker image.
+
+TODO: [Example call to Docker Build and Push workflow](./examples/)
+
+<details>
+  <summary>Workflow Input Variables</summary>
+
+| name         | description                                                        | type   | default     | required | 
+|:------------:|:-------------------------------------------------------------------|:------:|:------------|:--------:|
+| image_name   | Docker image name                                                  | string | None        | true     |
+| branch       | Git branch used for tagging incremental builds of the Docker image | string | master      | true     |
+| gcp_project  | GCP project where GCR is located for storing built Docker images   | string | None        | true     |
+| cluster_name | K8s cluster name on which Dagster workflow is deployed to          | string | None        | true     |
+
+#### Input Secrets
+These are the github repo secrets you must create ahead of time
+
+| name                      | description                                                | required | 
+|:-------------------------:|:-----------------------------------------------------------|:--------:|
+| SSH_KEY                   | SSH key used to access private repos during the build      | true     |
+| GCR_RW_SERVICEACCOUNT_KEY | GCR service account credentials to push/pull Docker images | true     |
+
+</details>
+
+
+## Deploy to Cloud Run (Optional: Create Sentry Release)
+This [workflow](./.github/workflows/) will deploy a docker image to a Cloud Run service and optionally create a sentry release.
+
+TODO: [Example call to cloudrun workflow](./examples/)
+
+<details>
+  <summary>Workflow Input Variables</summary>
+
+| name           | description                                                       | type    | default        | required | 
+|:--------------:|:------------------------------------------------------------------|:-------:|:---------------|:--------:|
+| image_name     | Docker image name                                                 | string  | None           | true     |
+| gcp_project    | GCP project where GCR is located for storing built Docker images  | string  | None           | true     |
+| cluster_name   | K8s cluster name on which Dagster workflow is deployed to         | string  | None           | true     |
+| cloud_run      | Whether or not to deploy to Google Cloud Run                      | boolean | true           | true     |
+| service_name   | Name of service to update in Cloud Run                            | string  | None           | true     |
+| sentry_release | Whether or not to create a Sentry release for the this project    | boolean | false          | true     |
+| environment    | Environment to deploy to: stage or prod                           | string  | None           | true     |
+
+#### Input Secrets
+These are the github repo secrets you must create ahead of time
+
+| name                      | description                                                | required | 
+|:-------------------------:|:-----------------------------------------------------------|:--------:|
+| SSH_KEY                   | SSH key used to access private repos during the build      | true     |
+| GCR_RW_SERVICEACCOUNT_KEY | GCR service account credentials to push/pull Docker images | true     |
+
+</details>
+
+
+## Yarn Build and Test
+This [workflow](./.github/workflows/yarn_build_test.yml) will build and test a yarn project.
+
+TODO: [Example call to yarn build and test workflow](./examples/)

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ These are the GitHub repo secrets you must create ahead of time!
 ## Deploy to Google Cloud Run (Optional: Create Sentry Release)
 This [workflow](./.github/workflows/) will deploy a docker image to a Cloud Run service and optionally create a sentry release.
 
-TODO: [Example call to cloudrun workflow](./examples/)
+[Example call to cloudrun workflow](./examples/cloudrun_deploy_optional_sentry.yml)
 
 <details>
   <summary>Workflow Input Variables</summary>

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This [workflow](./.github/workflows/docker_build_push.yml) will build and push a
 | name         | description                                                        | type   | default     | required | 
 |:------------:|:-------------------------------------------------------------------|:------:|:------------|:--------:|
 | image_name   | Docker image name                                                  | string | None        | true     |
-| branch       | Git branch used for tagging incremental builds of the Docker image | string | master      | true     |
+| branch       | Git branch used for tagging incremental builds of the Docker image | string | main        | true     |
 | gcp_project  | GCP project where GCR is located for storing built Docker images   | string | None        | true     |
 
 #### Input Secrets

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ These are the github repo secrets you must create ahead of time
 ## Docker Build and Push
 This [workflow](./.github/workflows/docker_build_push.yml) will build and push a docker image.
 
-TODO: [Example call to Docker Build and Push workflow](./examples/)
+[Example call to Docker Build and Push workflow](./examples/docker_build_push.yml)
 
 <details>
   <summary>Workflow Input Variables</summary>

--- a/README.md
+++ b/README.md
@@ -36,14 +36,15 @@ This [workflow](./.github/workflows/docker_build_push.yml) will build and push a
 <details>
   <summary>Workflow Input Variables</summary>
 
-| name                  | description                                                        | type   | default     | required |
-|:---------------------:|:-------------------------------------------------------------------|:------:|:------------|:--------:|
-| image_name            | Docker image name                                                  | string | None        | true     |
-| branch                | Git branch used for tagging incremental builds of the Docker image | string | main        | true     |
-| gcp_project           | GCP project where GCR is located for storing built Docker images   | string | None        | true     |
-| artifacts_object_name | Name of the artifacts object to pass to docker build job           | string | None        | false    |
-| artifacts_path        | Path to use for the artifacts object                               | string | `build/`    | false    |
+| name                  | description                                                        | type   | default  | required |
+|:---------------------:|:-------------------------------------------------------------------|:------:|:---------|:--------:|
+| image_name            | Docker image name                                                  | string | None     | true     |
+| branch                | Git branch used for tagging incremental builds of the Docker image | string | main     | true     |
+| gcp_project           | GCP project where GCR is located for storing built Docker images   | string | None     | true     |
+| artifacts_object_name | Name of the artifacts object to pass to docker build job           | string | None     | false    |
+| artifacts_path        | Path to use for the artifacts object                               | string | `build/` | false    |
 
+        
 #### Input Secrets
 These are the github repo secrets you must create ahead of time
 
@@ -65,9 +66,10 @@ TODO: [Example call to cloudrun workflow](./examples/)
 
 | name           | description                                                       | type    | default        | required | 
 |:--------------:|:------------------------------------------------------------------|:-------:|:---------------|:--------:|
+| gcp_project    | GCP project where GCR is located for storing built Docker images  | string  | None           | true     |
+| region         | Region to deploy cloudrun app and docker image                    | string  | `europe-west4` | false    |
 | image_name     | Docker image name                                                 | string  | None           | true     |
 | image_tag      | Name of Tag for Docker image                                      | string  | None           | false    |
-| gcp_project    | GCP project where GCR is located for storing built Docker images  | string  | None           | true     |
 | service_name   | Name of service to update in Cloud Run                            | string  | None           | true     |
 | sentry_release | Whether or not to create a Sentry release for the this project    | boolean | false          | false    |
 | environment    | Environment to deploy to: stage or prod                           | string  | None           | true     |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This [workflow](./.github/workflows/dagster.yml) will build a docker image and t
 | cluster_name | K8s cluster name on which Dagster workflow is deployed to          | string | None           | true     |
 
 #### Input Secrets
-These are the github repo secrets you must create ahead of time
+These are the GitHub repo secrets you must create ahead of time!
 
 | name                      | description                                                | required | 
 |:-------------------------:|:-----------------------------------------------------------|:--------:|
@@ -46,7 +46,7 @@ This [workflow](./.github/workflows/docker_build_push.yml) will build and push a
 
         
 #### Input Secrets
-These are the github repo secrets you must create ahead of time
+These are the GitHub repo secrets you must create ahead of time!
 
 | name                      | description                                                | required | 
 |:-------------------------:|:-----------------------------------------------------------|:--------:|
@@ -75,7 +75,7 @@ TODO: [Example call to cloudrun workflow](./examples/)
 | environment    | Environment to deploy to: stage or prod                           | string  | None           | true     |
 
 #### Input Secrets
-These are the github repo secrets you must create ahead of time
+These are the GitHub repo secrets you must create ahead of time!
 
 | name                                | description                                                | required  | 
 |:-----------------------------------:|:-----------------------------------------------------------|:---------:|
@@ -88,4 +88,6 @@ These are the github repo secrets you must create ahead of time
 ## Yarn Build and Test
 This [workflow](./.github/workflows/yarn_build_test.yml) will build and test a yarn project.
 
-TODO: [Example call to yarn build and test workflow](./examples/)
+[Example call to yarn build and test workflow](./examples/yarn_build_test.yml)
+
+Takes no inputs at this time.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ TODO: [Example call to cloudrun workflow](./examples/)
 | image_name     | Docker image name                                                 | string  | None           | true     |
 | gcp_project    | GCP project where GCR is located for storing built Docker images  | string  | None           | true     |
 | cluster_name   | K8s cluster name on which Dagster workflow is deployed to         | string  | None           | true     |
-| cloud_run      | Whether or not to deploy to Google Cloud Run                      | boolean | true           | true     |
 | service_name   | Name of service to update in Cloud Run                            | string  | None           | true     |
 | sentry_release | Whether or not to create a Sentry release for the this project    | boolean | false          | true     |
 | environment    | Environment to deploy to: stage or prod                           | string  | None           | true     |

--- a/README.md
+++ b/README.md
@@ -29,18 +29,20 @@ These are the github repo secrets you must create ahead of time
 
 
 ## Docker Build and Push
-This [workflow](./.github/workflows/docker_build_push.yml) will build and push a docker image.
+This [workflow](./.github/workflows/docker_build_push.yml) will build and push a docker image. You can optionally pass in artifacts from previous jobs with the `artifacts_object_name` and `artifacts_path` input variables, to ensure the docker image gets built with context from a previous job.
 
-[Example call to Docker Build and Push workflow](./examples/docker_build_push.yml)
+[Example call to Docker Build and Push workflow without artifacts](./examples/docker_build_push.yml)
 
 <details>
   <summary>Workflow Input Variables</summary>
 
-| name         | description                                                        | type   | default     | required | 
-|:------------:|:-------------------------------------------------------------------|:------:|:------------|:--------:|
-| image_name   | Docker image name                                                  | string | None        | true     |
-| branch       | Git branch used for tagging incremental builds of the Docker image | string | main        | true     |
-| gcp_project  | GCP project where GCR is located for storing built Docker images   | string | None        | true     |
+| name                  | description                                                        | type   | default     | required |
+|:---------------------:|:-------------------------------------------------------------------|:------:|:------------|:--------:|
+| image_name            | Docker image name                                                  | string | None        | true     |
+| branch                | Git branch used for tagging incremental builds of the Docker image | string | main        | true     |
+| gcp_project           | GCP project where GCR is located for storing built Docker images   | string | None        | true     |
+| artifacts_object_name | Name of the artifacts object to pass to docker build job           | string | None        | false    |
+| artifacts_path        | Path to use for the artifacts object                               | string | `build/`    | false    |
 
 #### Input Secrets
 These are the github repo secrets you must create ahead of time

--- a/examples/cloudrun_deploy_optional_sentry.yml
+++ b/examples/cloudrun_deploy_optional_sentry.yml
@@ -1,0 +1,22 @@
+name: release to prod
+
+# only deploy when a release is created in GitHub for this repo
+on:
+  release:
+    types: [published]
+
+jobs:
+  cloudrun_deploy:
+    uses: 20treeAI/github-workflows/.github/workflows/cloudrun_deploy_optional_sentry.yml@main
+    with:
+      image_name: my-beautiful-image
+      image_tag: prod
+      branch: main
+      gcp_project: myproj-1234
+      service_name: one-cool-cloud-run-service
+      sentry_release: true
+      environment: prod
+    secrets:
+      SSH_KEY: ${{ secrets.SSH_KEY }}
+      GCR_RW_SERVICEACCOUNT_KEY: ${{ secrets.GCR_RW_SERVICEACCOUNT_KEY }}
+      CLOUDRUN_DEPLOYER_SERVICEACCOUNT_KEY: ${{ secrets.CLOUDRUN_DEPLOYER_SERVICEACCOUNT_KEY }}

--- a/examples/dagster.yml
+++ b/examples/dagster.yml
@@ -1,0 +1,35 @@
+name: Build and push Docker images + test for dagster
+
+on:
+  pull_request: # Only builds image, does not deploy
+    types: [labeled, unlabeled, opened, synchronize, reopened, closed]
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+  push:
+    branches: # Build image, push tags latest/stage, deploy to stage
+      - main
+    tags: # Build image, push tags v0.X/prod, deploy to prod
+      - '*'
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  run-dagster-ci:
+    # this line shouldn't change, but make sure it's pointed at the main branch
+    uses: 20treeAI/github-workflows/.github/workflows/dagster.yml@main
+    with:
+      # name of the docker image to build
+      image_name: poles-lines-tools
+      # which github branch this is for
+      branch: main
+      # the gcp_project shouldn't be needed, but could in the future
+      # gcp_project: myproj-1234
+      # this is the name of the k8s cluster you'd like to deploy to
+      cluster_name: elm
+    # these must be created as github repo secrets
+    secrets:
+      SSH_KEY: ${{ secrets.OVERSTORY_BOT_SSH_KEY }}
+      GCR_RW_SERVICEACCOUNT_KEY: ${{ secrets.GCR_RW_SERVICEACCOUNT_KEY }}
+

--- a/examples/docker_build_push.yml
+++ b/examples/docker_build_push.yml
@@ -1,0 +1,28 @@
+name: build-push-deploy
+
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [labeled, unlabeled, opened, synchronize, reopened, closed]
+    branches:
+      - main
+
+jobs:
+  docker:
+    # query our module
+    uses: 20treeAI/github-workflows/.github/workflows/docker_build_push.yml@main
+    with:
+      # you can set this to any name for you docker image
+      image_name: docker-image-name
+      # which branch to build from
+      branch: main
+      # YOUR GCP project number
+      gcp_project: coolproj-1234
+    # you need to create these secrets in your repo ahead of time
+    secrets:
+      SSH_KEY: ${{ secrets.MY_SSH_KEY }}
+      GCR_RW_SERVICEACCOUNT_KEY: ${{ secrets.GCR_RW_SERVICEACCOUNT_KEY }}

--- a/examples/yarn_build_test.yml
+++ b/examples/yarn_build_test.yml
@@ -1,0 +1,30 @@
+name: Test, Build, and Push to stage
+
+on:
+  # Trigger the workflow on push or pull request to main
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [labeled, unlabeled, opened, synchronize, reopened, closed]
+    branches:
+      - main
+
+jobs:
+  # builds and tests the app with yarn
+  yarn_build_test:
+    uses: 20treeAI/github-workflows/.github/workflows/yarn_build_test.yml@main
+
+  # OPTIONAL: uses the build output from yarn to build and push a docker image to GCR
+  docker_build_push:
+    uses: 20treeAI/github-workflows/.github/workflows/docker_build_push.yml@main
+    needs: yarn_build_test
+    with:
+      image_name: my-beautiful-docker-image
+      branch: main
+      gcp_project: myproj-12345
+      artifacts_object_name: build-artifacts
+    # !! these must be created in as secrets in your repo ahead of time !!
+    secrets:
+      SSH_KEY: ${{ secrets.ORG_SSH_KEY }}
+      GCR_RW_SERVICEACCOUNT_KEY: ${{ secrets.GCR_RW_SERVICEACCOUNT_KEY }}


### PR DESCRIPTION
This is related to https://github.com/20treeAI/coregistration-tool/pull/72 

We've added workflows for building a yarn project and also for deploying to cloudrun! 🎉 And docs! We have docs now!

This will have to be squashed and merged because I did too many commits 🤷 