### PR TITLE
Fix dev-env cleanup step: remove postgres pvc

### DIFF
--- a/.github/workflows/dagster.yml
+++ b/.github/workflows/dagster.yml
@@ -236,6 +236,9 @@ jobs:
           chart: 'dagster/dagster'
           release: "${{ format('{0}-pr-{1}', inputs.image_name, github.event.number) }}"
           namespace: 'dagster'
+      # this has to be done manually to clean up the postgresql PVC
+      - name: 'Remove dev environment Persistent Volume Claim'
+        run: kubectl delete pvc -n dagster -l release=${{ format('{0}-pr-{1}', inputs.image_name, github.event.number) }}
       - uses: marocchino/sticky-pull-request-comment@v2
         name: 'Remove PR comment for dev-env'
         with:


### PR DESCRIPTION
Looks like we can't set the reclaim policy for the PVC that posgres creates anywhere in the bitnami postgres helm chart (the one that is bundled with dagster), so according to [bitnami's postgres docs](https://github.com/bitnami/charts/tree/main/bitnami/postgresql#uninstalling-the-chart) we'll just need to have a step to clean up the old PVC in our reusable github-workflows.