### PR TITLE
fix: failing helm deployment

### DIFF
--- a/.github/workflows/dagster.yml
+++ b/.github/workflows/dagster.yml
@@ -121,7 +121,7 @@ jobs:
         run: echo "REPOSITORY_PY_LOCATION=$(find . -maxdepth 2 -name repository.py)" >> $GITHUB_OUTPUT
 
       - name: Install dagster helm chart for developer environment
-        uses: vimeda/helm@v1.6.8
+        uses: vimeda/helm@v1.7.0
         with:
           helm: helm3
           repo: 'https://dagster-io.github.io/helm'
@@ -227,7 +227,7 @@ jobs:
           cluster_name: ${{ inputs.stage_cluster_name }}
           location: ${{ inputs.gcp_location }}
       - name: 'Remove dev environment from GKE'
-        uses: vimeda/helm@v1.6.8
+        uses: vimeda/helm@v1.7.0
         with:
           task: 'remove'
           helm: helm3


### PR DESCRIPTION
Fixing failing dagster deploy: https://github.com/20treeAI/active-learning/actions/runs/4755600075/jobs/8465355280?pr=39
Fix is in latest version of vimeda/helm: 
* v1.7.0 release notes: https://github.com/vimeda/helm/releases/tag/v1.7.0
* PR for fix: https://github.com/vimeda/helm/pull/16/files