### PR TITLE
updating actions/checkout to latest version

### DIFF
--- a/.github/workflows/dagster.yml
+++ b/.github/workflows/dagster.yml
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
@@ -102,7 +102,7 @@ jobs:
     needs: run-docker-workflow
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup SSH Keys and known_hosts
         shell: bash -l {0}


### PR DESCRIPTION
So we don't get warnings about old versions of node or something