### PR TITLE
Update docker_build_push google-github-actions/setup-gcloud action to latest version

### DIFF
--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -66,13 +66,14 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2.4.1
-
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0.2.1
+          
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v1'
         with:
-          project_id: ${{ inputs.gcp_project }}
-          service_account_key: ${{ secrets.GCR_RW_SERVICEACCOUNT_KEY }}
-          export_default_credentials: true
+          credentials_json: ${{ secrets.GCR_RW_SERVICEACCOUNT_KEY }}
+
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
 
       - name: Use glcoud CLI to configure-docker auth
         run: gcloud auth configure-docker
@@ -107,7 +108,6 @@ jobs:
           wget -O/tmp/grpc_health_probe -q https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.11/grpc_health_probe-linux-amd64
           chmod +x /tmp/grpc_health_probe
           for i in $(seq 1 10); do /tmp/grpc_health_probe -addr=localhost:8080 && s=0 && break || s=$? && sleep 2; done; (docker logs test_container && exit $s)
-
 
       - name: Push docker image
         uses: docker/build-push-action@v4.0.0


### PR DESCRIPTION
current version was causing node.js deprecation warnings in workflow summaries