### PR TITLE
Add push to prod workflow

### DIFF
--- a/.github/workflows/push_to_prod.yml
+++ b/.github/workflows/push_to_prod.yml
@@ -46,4 +46,3 @@ jobs:
           region: europe-west4
           image: '${{ inputs.image_name }}:${{ github.sha }}'
           credentials: ${{ secrets.CLOUDRUN_DEPLOYER_SERVICEACCOUNT_KEY }}
-

--- a/.github/workflows/push_to_prod.yml
+++ b/.github/workflows/push_to_prod.yml
@@ -1,0 +1,49 @@
+name: Push to Production
+
+on:
+  workflow_call:
+    inputs:
+      image_name:
+        description: 'Docker image name'
+        required: true
+        type: string
+      service_name:
+        description: 'Service name'
+        required: true
+        type: string
+
+    secrets:
+      SSH_KEY:
+        description: 'SSH key used to access private repos during the build'
+        required: true
+      GCR_RW_SERVICEACCOUNT_KEY:
+        description: 'GCR service account credentials to push/pull Docker images'
+        required: true
+jobs:
+  release-to-prod:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: 'actions/checkout@v3' # Required for auth
+
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GCR_RW_SERVICEACCOUNT_KEY }}'
+
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+
+      - name: Tag Docker image
+        run: |
+          gcloud container images add-tag ${{ inputs.image_name }}:${{ github.sha }} ${{ inputs.image_name }}:${{ github.event.release.tag_name }}
+          gcloud container images add-tag ${{ inputs.image_name }}:${{ github.sha }} ${{ inputs.image_name }}:prod
+
+      - name: Deploy to Cloud Run
+        uses: 'google-github-actions/deploy-cloudrun@v1'
+        with:
+          service: ${{ inputs.service_name }}
+          region: europe-west4
+          image: '${{ inputs.image_name }}:${{ github.sha }}'
+          credentials: ${{ secrets.CLOUDRUN_DEPLOYER_SERVICEACCOUNT_KEY }}
+


### PR DESCRIPTION
## Overview and Motivation

We've got "push-to-production" workflows across various repositories, including:

- [labelbox-webhooks](https://github.com/20treeAI/labelbox-webhooks/blob/main/.github/workflows/push_to_prod.yml)
- [navigator](https://github.com/20treeAI/navigator/blob/main/.github/workflows/push_to_prod.yml)
- [imagery-dashboard](https://github.com/20treeAI/imagery-dashboard/pull/3/files#diff-a4b4694911838b415e41fc34312c62f0a59dfee5e6cbe3b7e4a74ddb86d60926)

This is a first attempt at creating a unifying "push-to-prod" workflow which can potentially be shared by these repos down the line.

## Observations

Note the different tagging approaches:

- __gcloud CLI__
  The `gcloud` CLI is used in [imagery-dashboard](https://github.com/20treeAI/imagery-dashboard/pull/3/files#diff-a4b4694911838b415e41fc34312c62f0a59dfee5e6cbe3b7e4a74ddb86d60926)

```yml
      - name: Tag Docker image
        run: |
          gcloud container images add-tag ${{ inputs.image_name }}:${{ github.sha }} ${{ inputs.image_name }}:${{ github.event.release.tag_name }}
          gcloud container images add-tag ${{ inputs.image_name }}:${{ github.sha }} ${{ inputs.image_name }}:prod
```

- __Docker CLI__
    whereas the regular `docker` CLI is used in [labelbox-webhooks](https://github.com/20treeAI/labelbox-webhooks/blob/main/.github/workflows/push_to_prod.yml) and [navigator](https://github.com/20treeAI/navigator/blob/main/.github/workflows/push_to_prod.yml).

```yml
      - name: Use gcloud CLI
        run: |
          docker pull eu.gcr.io/tree-266510/labelbox-webhooks:${{ github.sha }}
          docker tag eu.gcr.io/tree-266510/labelbox-webhooks:${{ github.sha }} eu.gcr.io/tree-266510/labelbox-webhooks:${{ github.event.release.tag_name }}
          docker tag eu.gcr.io/tree-266510/labelbox-webhooks:${{ github.sha }} eu.gcr.io/tree-266510/labelbox-webhooks:prod
          docker push eu.gcr.io/tree-266510/labelbox-webhooks:${{ github.event.release.tag_name }}
          docker push eu.gcr.io/tree-266510/labelbox-webhooks:prod
```

The Docker approach "pushes" the container to GCR, but this shouldn't be necessary IIUC.

Ignoring the "pushing", I don't see a difference between these two approaches, and would probably recommend the `gcloud` CLI approach. __Curious on your input here.__
