### PR TITLE
change `defaults.run.working-directory` to `jobs.id.defaults.workfing-directory`

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -22,16 +22,13 @@ on:
         required: true
 env:
   SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-defaults:
-  run:
-    working-directory: ${{ inputs.terraform_directory }}
   
 jobs:
   terraform_test:
     runs-on: ubuntu-latest
     defaults:
       run:
-        shell: bash -l {0}
+        working-directory: ${{ inputs.terraform_directory }}
 
     steps:
     - uses: actions/checkout@v3
@@ -99,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        shell: bash -l {0}
+        working-directory: ${{ inputs.terraform_directory }}
 
     environment: ${{ inputs.terraform_workspace }}
     steps:


### PR DESCRIPTION
Changing this, as the current `defaults.run.working-directory` produces an error because inputs is not declared yet, I think.