### PR TITLE
add scheduled workflow for dagster

### DIFF
--- a/.github/workflows/dagster-scheduled-workflow.yml
+++ b/.github/workflows/dagster-scheduled-workflow.yml
@@ -31,12 +31,14 @@ on:
         required: true
         type: string
       prod_github_environment:
-        description: 'prod GitHub environment to recieve alerts on failure'
-        required: true
+        description: 'prod GitHub environment to receive alerts on failure'
+        default: 'prod'
+        required: false
         type: string
       stage_github_environment:
-        description: 'stage GitHub environment to recieve alerts on failure'
-        required: true
+        description: 'stage GitHub environment to receive alerts on failure'
+        default: 'stage'
+        required: false
         type: string
 
     secrets:

--- a/.github/workflows/dagster-scheduled-workflow.yml
+++ b/.github/workflows/dagster-scheduled-workflow.yml
@@ -56,7 +56,6 @@ jobs:
     needs: run-docker-workflow
     runs-on: ubuntu-latest
     steps:
-      # do we actually need this checkout? it's only used for the docker image right?
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/dagster-scheduled-workflow.yml
+++ b/.github/workflows/dagster-scheduled-workflow.yml
@@ -1,0 +1,108 @@
+---
+name: Dagster scheduled workflow - build, test and push a docker image for dagster to GCR nightly
+
+on:
+  workflow_call:
+    inputs:
+      image_name:
+        description: 'Docker image name'
+        required: true
+        type: string
+      branch:
+        description: 'Git branch used for tagging incremental builds of the Docker image'
+        default: 'main'
+        required: false
+        type: string
+      gcp_project:
+        description: 'GCP project where GKE/GCR are located for storing built Docker images'
+        required: true
+        type: string
+      gcp_location:
+        description: 'Location where GKE is located for storing built Docker images'
+        required: false
+        default: 'europe-west4'
+        type: string
+      cluster_name:
+        description: 'K8s cluster name on which Dagster jobs are deployed to'
+        required: true
+        type: string
+      stage_cluster_name:
+        description: 'K8s stage cluster name on which Dagster jobs are deployed to'
+        required: true
+        type: string
+
+    secrets:
+      SSH_KEY:
+        description: 'SSH key used to access private repos during the build'
+        required: true
+      GCR_RW_SERVICEACCOUNT_KEY:
+        description: 'GCR service account credentials to push/pull Docker images'
+        required: true
+
+jobs:
+  run-docker-workflow:
+    # query our reusable docker build and push workflow
+    uses: 20treeAI/github-workflows/.github/workflows/docker_build_push.yml@main
+    with:
+      image_name: ${{ inputs.image_name }}
+      branch: ${{ inputs.branch }}
+      gcp_project: ${{ inputs.gcp_project }}
+      test_dagster: true
+    secrets:
+      SSH_KEY: ${{ secrets.SSH_KEY }}
+      GCR_RW_SERVICEACCOUNT_KEY: ${{ secrets.GCR_RW_SERVICEACCOUNT_KEY }}
+
+  deploy-to-gke-stage:
+    needs: run-docker-workflow
+    runs-on: ubuntu-latest
+    steps:
+      # do we actually need this checkout? it's only used for the docker image right?
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GCR_RW_SERVICEACCOUNT_KEY }}'
+
+      - uses: 'google-github-actions/get-gke-credentials@v1'
+        name: 'Get GKE cluster credentials'
+        with:
+          cluster_name: ${{ inputs.stage_cluster_name }}
+          location: ${{ inputs.gcp_location }}
+
+      - name: Deploy to cluster
+        run: |
+          kubectl rollout restart deployment -n dagster dagster-dagster-user-deployments-${{ inputs.image_name }}
+          kubectl rollout status deployment -n dagster dagster-dagster-user-deployments-${{ inputs.image_name }} -w --timeout=10m
+          echo "Stage Deployment completed" || ( kubectl logs -n dagster -l deployment=${{ inputs.image_name }} && exit 1 )
+
+  deploy-to-gke-prod:
+    needs: deploy-to-gke-stage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GCR_RW_SERVICEACCOUNT_KEY }}'
+
+      - name: Re-tag stage image with prod
+        run: |
+          gcloud container images add-tag '${{ env.IMAGE_NAME }}:${{ github.sha }}' '${{ env.IMAGE_NAME }}:prod'
+
+      - uses: 'google-github-actions/get-gke-credentials@v1'
+        name: 'Get GKE cluster credentials'
+        with:
+          cluster_name: ${{ inputs.cluster_name }}
+          location: ${{ inputs.gcp_location }}
+
+      - name: Deploy to cluster
+        run: |
+          kubectl rollout restart deployment -n dagster dagster-dagster-user-deployments-${{ inputs.image_name }}
+          kubectl rollout status deployment -n dagster dagster-dagster-user-deployments-${{ inputs.image_name }} -w --timeout=10m
+          echo "Prod Deployment completed" || ( kubectl logs -n dagster -l deployment=${{ inputs.image_name }} && exit 1 )

--- a/.github/workflows/dagster-scheduled-workflow.yml
+++ b/.github/workflows/dagster-scheduled-workflow.yml
@@ -30,6 +30,14 @@ on:
         description: 'K8s stage cluster name on which Dagster jobs are deployed to'
         required: true
         type: string
+      prod_github_environment:
+        description: 'prod GitHub environment to recieve alerts on failure'
+        required: true
+        type: string
+      stage_github_environment:
+        description: 'stage GitHub environment to recieve alerts on failure'
+        required: true
+        type: string
 
     secrets:
       SSH_KEY:
@@ -54,6 +62,7 @@ jobs:
 
   deploy-to-gke-stage:
     needs: run-docker-workflow
+    environment: ${{ inputs.stage_github_environment }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -80,6 +89,7 @@ jobs:
   deploy-to-gke-prod:
     needs: deploy-to-gke-stage
     runs-on: ubuntu-latest
+    environment: ${{ inputs.prod_github_environment }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This [workflow](./.github/workflows/dagster.yml) will build a docker image and t
 
 This [workflow](./.github/workflows/dagster-scheduled-workflow.yml) will build a docker image and then test it before pushing it to GCR first in stage and then will retag for production. 
 
-[Example call to dagster workflow](./examples/dagster-nightly-rebuild.yml)
+[Example call to dagster workflow](./examples/dagster_nightly_rebuild.yml)
 
 <details>
   <summary>Workflow Input Variables</summary>

--- a/README.md
+++ b/README.md
@@ -33,13 +33,15 @@ This [workflow](./.github/workflows/dagster-scheduled-workflow.yml) will build a
 <details>
   <summary>Workflow Input Variables</summary>
 
-| name                               | description                                                                     |  type  | default      | required |
-| :--------------------------------- | :------------------------------------------------------------------------------ | :----: | :----------- | :------: |
-| image_name                         | Docker image name                                                               | string | None         |   true   |
-| gcp_project                        | GCP project where GCR/GKE are located for storing/deploying built Docker images | string | None         |   true   |
-| gcp_location                       | Location where GKE is located for storing built Docker images                   | string | europe-west4 |  false   |
-| cluster_name                       | K8s cluster name on which Dagster jobs are deployed to                          | string | None         |   true   |
-| stage_cluster_name                 | K8s stage cluster name on which Dagster jobs are deployed to                    | string | None         |   true   |
+| name                         | description                                                                     |  type  | default      | required |
+| :----------------------------| :------------------------------------------------------------------------------ | :----: | :----------- | :------: |
+| image_name                   | Docker image name                                                               | string | None         |   true   |
+| gcp_project                  | GCP project where GCR/GKE are located for storing/deploying built Docker images | string | None         |   true   |
+| gcp_location                 | Location where GKE is located for storing built Docker images                   | string | europe-west4 |  false   |
+| cluster_name                 | K8s cluster name on which Dagster jobs are deployed to                          | string | None         |   true   |
+| stage_cluster_name           | K8s stage cluster name on which Dagster jobs are deployed to                    | string | None         |   true   |
+| prod_github_environment      | The prod GitHub environment you'd like to use for deployments                   | string | None         |   true   |
+| stage_ github_environment    | The stage GitHub environment you'd like to use for deployments                  | string | None         |   true   |
 
 #### Input Secrets
 
@@ -167,6 +169,7 @@ This [workflow](./.github/workflows/terraform.yml) will deploy a private terrafo
 | name                | description                                                       | type    | default        | required | 
 |:-------------------:|:------------------------------------------------------------------|:-------:|:---------------|:--------:|
 | terraform_workspace | The terraform workspace you'd like to plan and deploy changes to  | string  | None           | true     |
+| github_environment  | The GitHub environment you'd like to use for deployments          | string  | None           | true     |
 
 #### Input Secrets
 These are the GitHub repo secrets you must create ahead of time!

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo contains [reusable workflows](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows) for Github Actions.
 
-## Dagster
+## Dagster Build, Test, Deploy
 
 This [workflow](./.github/workflows/dagster.yml) will build a docker image and then test it before pushing it to GCR. Also supports creating development environment in stage cluster if you label a PR `dev-env`. The development enviornment will be removed if you remove the label or close the PR.
 
@@ -23,6 +23,23 @@ This [workflow](./.github/workflows/dagster.yml) will build a docker image and t
 | stage_auth_domain                  | FQDN for authentication URL for cluster running dagster                         | string | None         |   true   |
 | stage_dagster_service_account_name | Development K8s cluster name on which Dagster jobs are deployed to              | string | None         |   true   |
 | dagster_version                    | Version of dagster to deploy helm chart for                                     | string | '0.15.10'    |  false   |
+
+## Dagster Scheduled Rebuild and Deploy
+
+This [workflow](./.github/workflows/dagster-scheduled-workflow.yml) will build a docker image and then test it before pushing it to GCR first in stage and then will retag for production. 
+
+[Example call to dagster workflow](./examples/dagster-nightly-rebuild.yml)
+
+<details>
+  <summary>Workflow Input Variables</summary>
+
+| name                               | description                                                                     |  type  | default      | required |
+| :--------------------------------- | :------------------------------------------------------------------------------ | :----: | :----------- | :------: |
+| image_name                         | Docker image name                                                               | string | None         |   true   |
+| gcp_project                        | GCP project where GCR/GKE are located for storing/deploying built Docker images | string | None         |   true   |
+| gcp_location                       | Location where GKE is located for storing built Docker images                   | string | europe-west4 |  false   |
+| cluster_name                       | K8s cluster name on which Dagster jobs are deployed to                          | string | None         |   true   |
+| stage_cluster_name                 | K8s stage cluster name on which Dagster jobs are deployed to                    | string | None         |   true   |
 
 #### Input Secrets
 

--- a/examples/dagster_nightly_rebuild.yml
+++ b/examples/dagster_nightly_rebuild.yml
@@ -14,7 +14,9 @@ jobs:
       branch: main
       gcp_project: projectcool-133742
       cluster_name: prod-cluster-name
+      prod_github_environment: prod
       stage_cluster_name: stage-cluster-name
+      stage_github_environment: stage
     secrets:
       SSH_KEY: ${{ secrets.SSH_KEY }}
       GCR_RW_SERVICEACCOUNT_KEY: ${{ secrets.GCR_RW_SERVICEACCOUNT_KEY }}

--- a/examples/dagster_nightly_rebuild.yml
+++ b/examples/dagster_nightly_rebuild.yml
@@ -1,0 +1,20 @@
+name: Nightly Build and Push Docker Image for Security Updates
+
+on:
+  # to rebuild the image nightly
+  schedule:
+    # every day at 01:00 UTC (1AM)
+    - cron: '0 1 * * *'
+
+jobs:
+  run-dagster-nightly-rebuild:
+    uses: 20treeAI/github-workflows/.github/workflows/dagster-scheduled-workflow.yml@main
+    with:
+      image_name: my-really-cool-dagster-app
+      branch: main
+      gcp_project: projectcool-133742
+      cluster_name: prod-cluster-name
+      stage_cluster_name: stage-cluster-name
+    secrets:
+      SSH_KEY: ${{ secrets.SSH_KEY }}
+      GCR_RW_SERVICEACCOUNT_KEY: ${{ secrets.GCR_RW_SERVICEACCOUNT_KEY }}

--- a/examples/dagster_nightly_rebuild.yml
+++ b/examples/dagster_nightly_rebuild.yml
@@ -16,7 +16,7 @@ jobs:
       # these are the names of your k8s clusters
       cluster_name: prod-cluster-name
       stage_cluster_name: stage-cluster-name
-      # this needs to be configured in your repo settings > environments
+      # these need to be configured in your repo settings > environments
       prod_github_environment: prod
       stage_github_environment: stage
     secrets:

--- a/examples/dagster_nightly_rebuild.yml
+++ b/examples/dagster_nightly_rebuild.yml
@@ -13,9 +13,11 @@ jobs:
       image_name: my-really-cool-dagster-app
       branch: main
       gcp_project: projectcool-133742
+      # these are the names of your k8s clusters
       cluster_name: prod-cluster-name
-      prod_github_environment: prod
       stage_cluster_name: stage-cluster-name
+      # this needs to be configured in your repo settings > environments
+      prod_github_environment: prod
       stage_github_environment: stage
     secrets:
       SSH_KEY: ${{ secrets.SSH_KEY }}


### PR DESCRIPTION
Separating out the workflow to be less complicated and more consistent.

nightly builds would then go like this:

job1: build and test docker image -> tag for stage, commit hash -> deploy to stage

If job1 successful, job2: retag for for prod -> deploy to prod

I haven't added a notification step, but it would be nice to add a slack notification only if build fails 🤔 