### PR TITLE
Update docker_build_push.yml - add job.id.with.docker = driver

### DIFF
--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -73,6 +73,9 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2.5.0
+        with:
+          # ref: https://github.com/docker/build-push-action/issues/321
+          driver: docker
 
       - id: 'auth'
         uses: 'google-github-actions/auth@v1'


### PR DESCRIPTION
This is to deal with size issues as described here:
https://github.com/docker/build-push-action/issues/321

Thanks to @chanange for finding this!