### PR TITLE
Add the SSH Key as secret

### DIFF
--- a/.github/workflows/dagster.yml
+++ b/.github/workflows/dagster.yml
@@ -69,7 +69,7 @@ jobs:
     # only run on synchronize PR event, meaning something has been pushed to the PR branch
     if: github.event_name == 'push' || contains(fromJSON('["opened", "synchronize", "reopened", "push"]'), github.event.action) || (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'dev-env')
     # query our reusable docker build and push workflow
-    uses: 20treeAI/github-workflows/.github/workflows/docker_build_push.yml@ssh-key
+    uses: 20treeAI/github-workflows/.github/workflows/docker_build_push.yml@ssh-secret
     with:
       image_name: ${{ inputs.image_name }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/dagster.yml
+++ b/.github/workflows/dagster.yml
@@ -69,7 +69,7 @@ jobs:
     # only run on synchronize PR event, meaning something has been pushed to the PR branch
     if: github.event_name == 'push' || contains(fromJSON('["opened", "synchronize", "reopened", "push"]'), github.event.action) || (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'dev-env')
     # query our reusable docker build and push workflow
-    uses: 20treeAI/github-workflows/.github/workflows/docker_build_push.yml@main
+    uses: 20treeAI/github-workflows/.github/workflows/docker_build_push.yml@ssh-key
     with:
       image_name: ${{ inputs.image_name }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -78,7 +78,7 @@ jobs:
         shell: bash -l {0}
 
       - name: Import SSH key
-        run: 'echo "${{secrets.SSH_KEY_BASE64}}" | base64 -d > /tmp/ssh_key'
+        run: 'echo "${{secrets.SSH_KEY}}" | base64 -d > /tmp/ssh_key'
         shell: bash -l {0}
     
       - if: ${{ inputs.artifacts_object_name }}

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -110,7 +110,9 @@ jobs:
           load: true
           tags: test-image
           ssh: default
-          build-args: "GIT_COMMIT=${{ github.sha }},SSH_KEY=${{ secrets.SSH_KEY }}"
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
+            SSH_KEY_BASE64=${{ secrets.SSH_KEY | base64 }}
           secret-files: BUILD_KEY=/tmp/build_key.json
           provenance: false
 

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -116,9 +116,9 @@ jobs:
           ssh: default
           build-args: |
             GIT_COMMIT=${{ github.sha }}
-          secret-files: |
-            BUILD_KEY=/tmp/build_key.json
-            SSH_KEY=/tmp/ssh_key
+          secrets: |
+            SSH_KEY=${{ secrets.SSH_KEY }}
+          secret-files: BUILD_KEY=/tmp/build_key.json
           provenance: false
 
       - if: ${{ inputs.test_dagster }}

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -78,7 +78,7 @@ jobs:
         shell: bash -l {0}
 
       - name: Import SSH key
-        run: echo "SSH_KEY_BASE64=$(echo '${{secrets.SSH_KEY}}' | base64)" >> $GITHUB_ENV
+        run: 'echo "${{secrets.SSH_KEY}}" | base64 -d > /tmp/ssh_key'
         shell: bash -l {0}
     
       - if: ${{ inputs.artifacts_object_name }}
@@ -116,8 +116,9 @@ jobs:
           ssh: default
           build-args: |
             GIT_COMMIT=${{ github.sha }}
-            SSH_KEY_BASE64=${{ env.SSH_KEY_BASE64 }} 
-          secret-files: BUILD_KEY=/tmp/build_key.json
+          secret-files: |
+            BUILD_KEY=/tmp/build_key.json
+            SSH_KEY=/tmp/ssh_key
           provenance: false
 
       - if: ${{ inputs.test_dagster }}
@@ -146,7 +147,9 @@ jobs:
           push: ${{ !inputs.skip_image_push }}
           ssh: default
           build-args: "GIT_COMMIT=${{ github.sha }}"
-          secret-files: BUILD_KEY=/tmp/build_key.json
+          secret-files: |
+            BUILD_KEY=/tmp/build_key.json
+            SSH_KEY=/tmp/ssh_key
           tags: |
             "${{ env.IMAGE_NAME }}:${{ github.sha }}"
             ${{ github.event_name == 'pull_request' && format('{0}:pr-{1}', env.IMAGE_NAME, github.event.number) || '' }}

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -80,6 +80,9 @@ jobs:
       - name: Import SSH key
         run: 'echo "${{secrets.SSH_KEY}}" > /tmp/ssh_key'
         shell: bash -l {0}
+        
+      - name: Check SSH Key Size
+        run: du -hs /tmp/ssh_key
     
       - if: ${{ inputs.artifacts_object_name }}
         name: Download artifacts

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -77,6 +77,10 @@ jobs:
         run: 'echo "${{secrets.DOCKER_BUILD_SERVICEACCOUNT_KEY}}" | base64 -d > /tmp/build_key.json'
         shell: bash -l {0}
 
+      - name: Import SSH key
+        run: 'echo "${{secrets.SSH_KEY_BASE64}}" | base64 -d > /tmp/ssh_key'
+        shell: bash -l {0}
+    
       - if: ${{ inputs.artifacts_object_name }}
         name: Download artifacts
         uses: actions/download-artifact@v3
@@ -112,8 +116,9 @@ jobs:
           ssh: default
           build-args: |
             GIT_COMMIT=${{ github.sha }}
-            SSH_KEY_BASE64=${{ secrets.SSH_KEY | base64 }}
-          secret-files: BUILD_KEY=/tmp/build_key.json
+          secret-files: |
+            BUILD_KEY=/tmp/build_key.json
+            SSH_KEY=/tmp/ssh_key
           provenance: false
 
       - if: ${{ inputs.test_dagster }}

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -78,7 +78,7 @@ jobs:
         shell: bash -l {0}
 
       - name: Import SSH key
-        run: 'echo "${{secrets.SSH_KEY}}" | base64 -d > /tmp/ssh_key'
+        run: 'echo "${{secrets.SSH_KEY}}" > /tmp/ssh_key'
         shell: bash -l {0}
     
       - if: ${{ inputs.artifacts_object_name }}

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -67,7 +67,6 @@ jobs:
         shell: bash -l {0}
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-          SSH_KEY_ENV: ${{ secrets.SSH_KEY }}
         run: |
           mkdir -p ~/.ssh
           ssh-keyscan github.com >> ~/.ssh/known_hosts
@@ -111,7 +110,7 @@ jobs:
           load: true
           tags: test-image
           ssh: default
-          build-args: "GIT_COMMIT=${{ github.sha }}"
+          build-args: "GIT_COMMIT=${{ github.sha }},SSH_KEY=${{ secrets.SSH_KEY }}"
           secret-files: BUILD_KEY=/tmp/build_key.json
           provenance: false
 

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -78,7 +78,7 @@ jobs:
         shell: bash -l {0}
 
       - name: Import SSH key
-        run: 'echo "${{secrets.SSH_KEY}}" | base64 -d > /tmp/ssh_key'
+        run: echo "SSH_KEY_BASE64=$(echo '${{secrets.SSH_KEY}}' | base64)" >> $GITHUB_ENV
         shell: bash -l {0}
     
       - if: ${{ inputs.artifacts_object_name }}
@@ -116,8 +116,7 @@ jobs:
           ssh: default
           build-args: |
             GIT_COMMIT=${{ github.sha }}
-          secrets: |
-            SSH_KEY=${{ secrets.SSH_KEY }}
+            SSH_KEY_BASE64=${{ env.SSH_KEY_BASE64 }} 
           secret-files: BUILD_KEY=/tmp/build_key.json
           provenance: false
 

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -67,6 +67,7 @@ jobs:
         shell: bash -l {0}
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+          SSH_KEY_ENV: ${{ secrets.SSH_KEY }}
         run: |
           mkdir -p ~/.ssh
           ssh-keyscan github.com >> ~/.ssh/known_hosts


### PR DESCRIPTION
I'm doing this so that I'll be able to use git from within a dagster pipeline (to check the latest version of s2p-pipelines that is in production). 

This is used [here](https://github.com/20treeAI/chm-benchmark/pull/10/files#diff-e53c733efc7eafc223ca2294715e4c849fded5d104bd28d9fae276110bd131edR207-R259) in this PR https://github.com/20treeAI/chm-benchmark/pull/10