### PR TITLE
Add option to provide SSH keys to Python CI

### DIFF
--- a/.github/workflows/python_library_ci.yml
+++ b/.github/workflows/python_library_ci.yml
@@ -43,7 +43,7 @@ on:
       TEST_SERVICEACCOUNT_KEY:
         description: 'Service account key with access to resources needed for running tests'
         required: false
-      OVERSTORY_BOT_SSH_KEY:
+      SSH_KEY:
         description: 'SSH key to access packages installed using ssh'
         required: false
 
@@ -77,7 +77,7 @@ jobs:
           mkdir -p ~/.ssh
           ssh-keyscan github.com >> ~/.ssh/known_hosts
           ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-          ssh-add - <<< "${{ secrets.OVERSTORY_BOT_SSH_KEY }}"
+          ssh-add - <<< "${{ secrets.SSH_KEY }}"
 
 
       - name: Install poetry

--- a/.github/workflows/python_library_ci.yml
+++ b/.github/workflows/python_library_ci.yml
@@ -36,6 +36,11 @@ on:
         default: false
         required: false
         type: bool
+      ssh_key_value:
+        description: 'SSH key to access packages installed using ssh'
+        default: false
+        required: false
+        type: string
     secrets:
       REGISTRY_RW_SERVICEACCOUNT_KEY:
         description: 'Service account key to access the registry for publishing artifacts'
@@ -43,20 +48,17 @@ on:
       TEST_SERVICEACCOUNT_KEY:
         description: 'Service account key with access to resources needed for running tests'
         required: false
-      OVERSTORY_BOT_SSH_KEY:
-        description: 'SSH key to access packages installed using ssh'
-        required: false
 
 jobs:
   ci:
     runs-on: ubuntu-latest
-    env:
-      GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcloud_key.json
-      SSH_AUTH_SOCK: /tmp/ssh_agent.sock
     defaults:
       run:
         shell: bash -el {0}
         working-directory: ${{ inputs.working_directory }}
+    env:
+      GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcloud_key.json
+      SSH_AUTH_SOCK: /tmp/ssh_agent.sock
     steps:
       - uses: actions/checkout@v3
 
@@ -64,22 +66,20 @@ jobs:
         if: inputs.conda_env_file == ''
         with:
           python-version: ${{ inputs.python_version }}
-
       - uses: conda-incubator/setup-miniconda@v2
         if: inputs.conda_env_file != ''
         with:
           activate-environment: ci-env
           environment-file: ${{ inputs.conda_env_file }}
-
+          
       - name: Setup SSH Keys and known_hosts
         if: inputs.provide_ssh_access
         run: |
           mkdir -p ~/.ssh
           ssh-keyscan github.com >> ~/.ssh/known_hosts
           ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-          ssh-add - <<< "${{ secrets.OVERSTORY_BOT_SSH_KEY }}"
-
-
+          ssh-add - <<< "${{ inputs.ssh_key_value }}"
+          
       - name: Install poetry
         uses: snok/install-poetry@v1
         with:

--- a/.github/workflows/python_library_ci.yml
+++ b/.github/workflows/python_library_ci.yml
@@ -43,6 +43,9 @@ on:
       TEST_SERVICEACCOUNT_KEY:
         description: 'Service account key with access to resources needed for running tests'
         required: false
+      OVERSTORY_BOT_SSH_KEY:
+        description: 'SSH key to access packages installed using ssh'
+        required: false
 
 jobs:
   ci:
@@ -58,7 +61,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup SSH Keys and known_hosts
-        if: inputs.conda_env_file == ''
+        if: inputs.provide_ssh_access
         run: |
           mkdir -p ~/.ssh
           ssh-keyscan github.com >> ~/.ssh/known_hosts
@@ -66,7 +69,7 @@ jobs:
           ssh-add - <<< "${{ secrets.OVERSTORY_BOT_SSH_KEY }}"
 
       - uses: actions/setup-python@v4
-        if: inputs.provide_ssh_access
+        if: inputs.conda_env_file == ''
         with:
           python-version: ${{ inputs.python_version }}
 

--- a/.github/workflows/python_library_ci.yml
+++ b/.github/workflows/python_library_ci.yml
@@ -35,7 +35,7 @@ on:
         description: 'Set to true if the project has packages installed using ssh'
         default: false
         required: false
-        type: bool
+        type: boolean
     secrets:
       REGISTRY_RW_SERVICEACCOUNT_KEY:
         description: 'Service account key to access the registry for publishing artifacts'
@@ -78,7 +78,6 @@ jobs:
           ssh-keyscan github.com >> ~/.ssh/known_hosts
           ssh-agent -a $SSH_AUTH_SOCK > /dev/null
           ssh-add - <<< "${{ secrets.SSH_KEY }}"
-
 
       - name: Install poetry
         uses: snok/install-poetry@v1

--- a/.github/workflows/python_library_ci.yml
+++ b/.github/workflows/python_library_ci.yml
@@ -36,11 +36,6 @@ on:
         default: false
         required: false
         type: bool
-      ssh_key_value:
-        description: 'SSH key to access packages installed using ssh'
-        default: false
-        required: false
-        type: string
     secrets:
       REGISTRY_RW_SERVICEACCOUNT_KEY:
         description: 'Service account key to access the registry for publishing artifacts'
@@ -48,17 +43,20 @@ on:
       TEST_SERVICEACCOUNT_KEY:
         description: 'Service account key with access to resources needed for running tests'
         required: false
+      OVERSTORY_BOT_SSH_KEY:
+        description: 'SSH key to access packages installed using ssh'
+        required: false
 
 jobs:
   ci:
     runs-on: ubuntu-latest
+    env:
+      GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcloud_key.json
+      SSH_AUTH_SOCK: /tmp/ssh_agent.sock
     defaults:
       run:
         shell: bash -el {0}
         working-directory: ${{ inputs.working_directory }}
-    env:
-      GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcloud_key.json
-      SSH_AUTH_SOCK: /tmp/ssh_agent.sock
     steps:
       - uses: actions/checkout@v3
 
@@ -66,20 +64,22 @@ jobs:
         if: inputs.conda_env_file == ''
         with:
           python-version: ${{ inputs.python_version }}
+
       - uses: conda-incubator/setup-miniconda@v2
         if: inputs.conda_env_file != ''
         with:
           activate-environment: ci-env
           environment-file: ${{ inputs.conda_env_file }}
-          
+
       - name: Setup SSH Keys and known_hosts
         if: inputs.provide_ssh_access
         run: |
           mkdir -p ~/.ssh
           ssh-keyscan github.com >> ~/.ssh/known_hosts
           ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-          ssh-add - <<< "${{ inputs.ssh_key_value }}"
-          
+          ssh-add - <<< "${{ secrets.OVERSTORY_BOT_SSH_KEY }}"
+
+
       - name: Install poetry
         uses: snok/install-poetry@v1
         with:

--- a/.github/workflows/python_library_ci.yml
+++ b/.github/workflows/python_library_ci.yml
@@ -60,14 +60,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup SSH Keys and known_hosts
-        if: inputs.provide_ssh_access
-        run: |
-          mkdir -p ~/.ssh
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
-          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-          ssh-add - <<< "${{ secrets.OVERSTORY_BOT_SSH_KEY }}"
-
       - uses: actions/setup-python@v4
         if: inputs.conda_env_file == ''
         with:
@@ -78,6 +70,15 @@ jobs:
         with:
           activate-environment: ci-env
           environment-file: ${{ inputs.conda_env_file }}
+
+      - name: Setup SSH Keys and known_hosts
+        if: inputs.provide_ssh_access
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+          ssh-add - <<< "${{ secrets.OVERSTORY_BOT_SSH_KEY }}"
+
 
       - name: Install poetry
         uses: snok/install-poetry@v1

--- a/.github/workflows/python_library_ci.yml
+++ b/.github/workflows/python_library_ci.yml
@@ -31,6 +31,11 @@ on:
         description: 'If conda is used, the location of the conda environment file'
         required: false
         type: string
+      provide_ssh_access:
+        description: 'Set to true if the project has packages installed using ssh'
+        default: false
+        required: false
+        type: bool
     secrets:
       REGISTRY_RW_SERVICEACCOUNT_KEY:
         description: 'Service account key to access the registry for publishing artifacts'
@@ -44,6 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcloud_key.json
+      SSH_AUTH_SOCK: /tmp/ssh_agent.sock
     defaults:
       run:
         shell: bash -el {0}
@@ -51,8 +57,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v4
+      - name: Setup SSH Keys and known_hosts
         if: inputs.conda_env_file == ''
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+          ssh-add - <<< "${{ secrets.OVERSTORY_BOT_SSH_KEY }}"
+
+      - uses: actions/setup-python@v4
+        if: inputs.provide_ssh_access
         with:
           python-version: ${{ inputs.python_version }}
 


### PR DESCRIPTION
In https://github.com/20treeAI/risk_score/pull/365, we are importing the `risk_score` as a `dev` dependency so that we can validate the `run_config`s generated from the SDK to the actual job in `risk_score` itself.

However, `risk_score` depends on `viaduct`, which is currently installed using ssh, meaning the CI for the SDK needs ssh access when running in the CI.