### PR TITLE
perf: use google actions cache for docker layers

### DIFF
--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -113,6 +113,8 @@ jobs:
           build-args: "GIT_COMMIT=${{ github.sha }}"
           secret-files: BUILD_KEY=/tmp/build_key.json
           provenance: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - if: ${{ inputs.test_dagster }}
         name: Find repository.py file


### PR DESCRIPTION
Add docker layer caching: 
https://depot.dev/blog/docker-layer-caching-in-github-actions