### PR TITLE
perf: use mamba instead of conda

### DIFF
--- a/.github/workflows/python_library_ci.yml
+++ b/.github/workflows/python_library_ci.yml
@@ -69,6 +69,8 @@ jobs:
         if: inputs.conda_env_file != ''
         with:
           activate-environment: ci-env
+          miniforge-variant: Mambaforge
+          use-mamba: true
           environment-file: ${{ inputs.conda_env_file }}
 
       - name: Setup SSH Keys and known_hosts


### PR DESCRIPTION
This has been working nicely for repos that do not use this template.