### PR TITLE
Add GDAL python repository workflow

### DIFF
--- a/.github/workflows/python_dagster_ci.yml
+++ b/.github/workflows/python_dagster_ci.yml
@@ -1,0 +1,132 @@
+name: CI pipeline for GDAL Python repositories 
+
+## Assumptions
+# 1. conda env file is called env.yml
+# 2. poetry (pyproject.toml and poetry.lock files)
+# 3. repository name = conda env name = package name
+# 4. uses pre-commit hooks
+# 5. slow tests are run on push to main only, not in every CI run
+# 6. 
+
+on:
+  workflow_call:
+    inputs:
+      repository_name:
+        description: 'Name of conda environment, python package'
+        required: true
+        type: string
+      gdal_version:
+        description: 'version of GDAL being used e.g. 3.6.4'
+        default: '3.6.4'
+        required: false
+        type: string
+      python_version:
+        description: 'Python version for building lib'
+        default: '3.10.6'
+        required: false
+        type: string
+      poetry_version:
+        description: 'Poetry version for building lib'
+        default: '1.5.1'
+        required: false
+        type: string
+      use_pytest_xdist:
+        description: 'Set to true of pytest-xdist is installed to run tests in parallel'
+        default: false
+        required: false
+        type: boolean
+      pytest_fast_conditions:
+        description: 'Conditions determining when fast tests should be run using pytest markers'
+        default: "not slow"
+        required: false
+        type: string
+      pytest_slow_conditions:
+        description: 'Conditions determining when slow tests should be run using pytest markers'
+        default: "slow"
+        required: false
+        type: string
+    secrets:
+      REGISTRY_RW_SERVICEACCOUNT_KEY:
+        description: 'Service account key to access the registry for publishing artifacts'
+        required: true
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    env:
+      GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcloud_key.json
+      SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+    defaults:
+      run:
+        shell: bash -el {0}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      # NOTE: This must run before the env restore, changed LD_LIBRARY_PATH can cause OpenSSL mismatch errors
+      - name: Setup SSH Keys and known_hosts
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+          ssh-add - <<< "${{ secrets.OVERSTORY_BOT_SSH_KEY }}"
+
+      # CONDA
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          activate-environment: ${{ inputs.repository_name }}
+
+        # Save the conda environment to cache.
+        # NOTE automatically invalidates cache monthly OR on any change of the env.yml or poetry.lock files
+        # Edit this portion to adjust cache "lifetime"
+      - name: Save date for cache keys
+        run: echo "MONTH=$(date +'%Y%m')" >> $GITHUB_ENV 
+      - name: Cache Conda env
+        uses: actions/cache@v3
+        id: conda-env-cache
+        with:
+          path: /usr/share/miniconda3/envs/${{ inputs.repository_name }}
+          key: conda-${{ env.MONTH }}-${{ hashFiles('env.yml') }}-${{ hashFiles('poetry.lock') }}
+
+        # Only install conda packages if the cache is invalidated
+      - name: Install conda packages
+        if: steps.conda-env-cache.outputs.cache-hit != 'true'
+        run: mamba env update -n ${{ inputs.repository_name }} -f env.yml
+
+      - name: Install poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: ${{ inputs.poetry_version }}
+
+      # POETRY INSTALL
+      - name: Install package
+        run: |
+          echo "${{ secrets.GAR_RW_PYTHON_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
+          poetry self add keyrings-google-artifactregistry-auth==1.0.0
+          poetry install
+
+      # FORMATTING
+      - name: Run Pre-commit Hooks
+        run: pre-commit run --all
+
+      - name: Import GCS key for tests
+        run: echo "${{ secrets.GCR_RW_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
+
+      # TESTS (FAST and SLOW)
+      - name: Run fast tests
+        run: | 
+          if ${{ inputs.use_pytext_xdist }}; then
+            pytest --durations=0 -m '"${{ inputs.pytest_fast_conditions }}"' -n auto --disable-warnings
+          else
+            pytest --durations=0 -m '"${{ inputs.pytest_fast_conditions }}"' --disable-warnings
+          fi
+      - if: github.event_name == 'push'
+        name: Run slow tests
+        run: | 
+          if ${{ inputs.use_pytext_xdist }}; then
+            pytest --durations=0 -m '"${{ inputs.pytest_slow_conditions }}"' -n auto --disable-warnings
+          else
+            pytest --durations=0 -m '"${{ inputs.pytest_slow_conditions }}"' --disable-warnings
+          fi

--- a/.github/workflows/python_gdal_ci.yml
+++ b/.github/workflows/python_gdal_ci.yml
@@ -34,9 +34,9 @@ on:
       
       # Testing arguments for two-stage tests 
       test_stage_1_should_run:
-        description: 'Set to true to use the subsequent settings to run tests'
+        description: 'Set to true to run the stage 1 tests as defined below'
         default: true
-        required: true
+        required: false
         type: boolean
       test_stage_1_use_pytest_xdist:
         description: 'Set to true to use pytest-xdist to run stage 1 tests in parallel (expects pytext-xdist to be installed)'
@@ -44,13 +44,13 @@ on:
         required: false
         type: boolean
       test_stage_1_conditions:
-        description: 'Pytest marker conditions for stage 1 tests'
-        default: ""
+        description: 'Pytest marker conditions for stage 1 tests to include/exclude tests'
+        default: ''
         required: false
         type: string
 
       test_stage_2_should_run:
-        description: 'Set to true to use the subsequent settings to run tests'
+        description: 'Set to true to run the stage 2 tests as defined below'
         default: false
         required: false
         type: boolean
@@ -60,12 +60,12 @@ on:
         required: false
         type: boolean
       test_stage_2_conditions:
-        description: 'Pytest marker conditions for stage 2 tests'
-        default: "slow"
+        description: 'Pytest marker conditions for stage 2 tests to include/exclude tests'
+        default: 'slow'
         required: false
         type: string
       test_stage_2_run_in_branch:
-        description: 'Set to true if tests should be run for each PR iteration, or False for tests to only run when merged to main'
+        description: 'Set to true for stage 2 tests to be run for each commit in the PR, or False for tests to only run when merged to main'
         default: true
         required: false
         type: boolean

--- a/.github/workflows/python_gdal_ci.yml
+++ b/.github/workflows/python_gdal_ci.yml
@@ -119,12 +119,10 @@ jobs:
       - name: Run Pre-commit Hooks
         run: pre-commit run --all
 
-      - name: Import GCS key for tests
-        run: echo "${{ secrets.TEST_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
-
       # TESTS (FAST and SLOW)
       - name: Run fast tests
         run: | 
+          echo "${{ secrets.TEST_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
           if [ ${{ inputs.use_pytest_xdist }} ]; then
             pytest --durations=0 -m '${{ inputs.pytest_fast_conditions }}' -n auto --disable-warnings
           else
@@ -134,6 +132,7 @@ jobs:
       - if: github.event_name == 'push'
         name: Run slow tests
         run: | 
+          echo "${{ secrets.TEST_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
           if [ ${{ inputs.use_pytest_xdist }} ]; then
             pytest --durations=0 -m '"${{ inputs.pytest_slow_conditions }}"' -n auto --disable-warnings
           else

--- a/.github/workflows/python_gdal_ci.yml
+++ b/.github/workflows/python_gdal_ci.yml
@@ -159,7 +159,7 @@ jobs:
         name: Run Stage 2 Tests
         run: | 
           echo "${{ secrets.TEST_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
-          if [ ${{ inputs.test_stage_1_use_pytest_xdist }} ]; then
+          if [ ${{ inputs.test_stage_2_use_pytest_xdist }} ]; then
             pytest --durations=0 -m '${{ inputs.test_stage_2_conditions }}' -n auto --disable-warnings
           else
             pytest --durations=0 -m '${{ inputs.test_stage_2_conditions }}' --disable-warnings

--- a/.github/workflows/python_gdal_ci.yml
+++ b/.github/workflows/python_gdal_ci.yml
@@ -68,7 +68,7 @@ on:
         type: boolean
 
     secrets:
-      GAR_RW_PYTHON_SERVICEACCOUNT_KEY:
+      REGISTRY_RW_SERVICEACCOUNT_KEY:
         description: 'Service account key to access the registry for publishing artifacts'
         required: true
       SSH_KEY:
@@ -133,7 +133,7 @@ jobs:
       # POETRY INSTALL
       - name: Install package
         run: |
-          echo "${{ secrets.GAR_RW_PYTHON_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
+          echo "${{ secrets.REGISTRY_RW_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
           poetry self add keyrings-google-artifactregistry-auth==1.0.0
           poetry install
 

--- a/.github/workflows/python_gdal_ci.yml
+++ b/.github/workflows/python_gdal_ci.yml
@@ -54,7 +54,7 @@ on:
         required: true
       TEST_SERVICEACCOUNT_KEY:
         description: 'Service account key with access to resources needed for running tests'
-        required: false
+        required: true
 
 
 
@@ -120,21 +120,22 @@ jobs:
         run: pre-commit run --all
 
       - name: Import GCS key for tests
-        run: echo "${{ secrets.GAR_RW_PYTHON_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
+        run: echo "${{ secrets.TEST_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
 
       # TESTS (FAST and SLOW)
       - name: Run fast tests
         run: | 
-          if ${{ inputs.use_pytext_xdist }}; then
+          if ${{ inputs.use_pytest_xdist }}; then
             pytest --durations=0 -m '${{ inputs.pytest_fast_conditions }}' -n auto --disable-warnings
-          else; then
+          else then
             pytest --durations=0 -m '${{ inputs.pytest_fast_conditions }}' --disable-warnings
           fi
+
       - if: github.event_name == 'push'
         name: Run slow tests
         run: | 
-          if ${{ inputs.use_pytext_xdist }}; then
+          if ${{ inputs.use_pytest_xdist }}; then
             pytest --durations=0 -m '"${{ inputs.pytest_slow_conditions }}"' -n auto --disable-warnings
-          else; then
+          else then
             pytest --durations=0 -m '"${{ inputs.pytest_slow_conditions }}"' --disable-warnings
           fi

--- a/.github/workflows/python_gdal_ci.yml
+++ b/.github/workflows/python_gdal_ci.yml
@@ -155,7 +155,7 @@ jobs:
             pytest --durations=0 -m '${{ inputs.test_stage_1_conditions }}' --disable-warnings
           fi
 
-      - if: inputs.test_stage_2_should_run || github.event_name == 'push'
+      - if: (test_stage_2_should_run) && (inputs.test_stage_2_run_in_branch || github.event_name == 'push')
         name: Run Stage 2 Tests
         run: | 
           echo "${{ secrets.TEST_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS

--- a/.github/workflows/python_gdal_ci.yml
+++ b/.github/workflows/python_gdal_ci.yml
@@ -126,15 +126,15 @@ jobs:
       - name: Run fast tests
         run: | 
           if ${{ inputs.use_pytext_xdist }}; then
-            pytest --durations=0 -m '"${{ inputs.pytest_fast_conditions }}"' -n auto --disable-warnings
-          else
-            pytest --durations=0 -m '"${{ inputs.pytest_fast_conditions }}"' --disable-warnings
+            pytest --durations=0 -m '${{ inputs.pytest_fast_conditions }}' -n auto --disable-warnings
+          else; then
+            pytest --durations=0 -m '${{ inputs.pytest_fast_conditions }}' --disable-warnings
           fi
       - if: github.event_name == 'push'
         name: Run slow tests
         run: | 
           if ${{ inputs.use_pytext_xdist }}; then
             pytest --durations=0 -m '"${{ inputs.pytest_slow_conditions }}"' -n auto --disable-warnings
-          else
+          else; then
             pytest --durations=0 -m '"${{ inputs.pytest_slow_conditions }}"' --disable-warnings
           fi

--- a/.github/workflows/python_gdal_ci.yml
+++ b/.github/workflows/python_gdal_ci.yml
@@ -155,7 +155,7 @@ jobs:
             pytest --durations=0 -m '${{ inputs.test_stage_1_conditions }}' --disable-warnings
           fi
 
-      - if: (test_stage_2_should_run) && (inputs.test_stage_2_run_in_branch || github.event_name == 'push')
+      - if: (inputs.test_stage_2_should_run) && (inputs.test_stage_2_run_in_branch || github.event_name == 'push')
         name: Run Stage 2 Tests
         run: | 
           echo "${{ secrets.TEST_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS

--- a/.github/workflows/python_gdal_ci.yml
+++ b/.github/workflows/python_gdal_ci.yml
@@ -125,9 +125,9 @@ jobs:
       # TESTS (FAST and SLOW)
       - name: Run fast tests
         run: | 
-          if ${{ inputs.use_pytest_xdist }}; then
+          if [ ${{ inputs.use_pytest_xdist }} ]; then
             pytest --durations=0 -m '${{ inputs.pytest_fast_conditions }}' -n auto --disable-warnings
-          else; then
+          else
             pytest --durations=0 -m '${{ inputs.pytest_fast_conditions }}' --disable-warnings
           fi
 

--- a/.github/workflows/python_gdal_ci.yml
+++ b/.github/workflows/python_gdal_ci.yml
@@ -46,9 +46,17 @@ on:
         required: false
         type: string
     secrets:
-      REGISTRY_RW_SERVICEACCOUNT_KEY:
+      GAR_RW_PYTHON_SERVICEACCOUNT_KEY:
         description: 'Service account key to access the registry for publishing artifacts'
         required: true
+      SSH_KEY:
+        description: 'SSH key used to access private repos during the build'
+        required: true
+      TEST_SERVICEACCOUNT_KEY:
+        description: 'Service account key with access to resources needed for running tests'
+        required: false
+
+
 
 jobs:
   ci:
@@ -69,7 +77,7 @@ jobs:
           mkdir -p ~/.ssh
           ssh-keyscan github.com >> ~/.ssh/known_hosts
           ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-          ssh-add - <<< "${{ secrets.OVERSTORY_BOT_SSH_KEY }}"
+          ssh-add - <<< "${{ secrets.SSH_KEY }}"
 
       # CONDA
       - uses: conda-incubator/setup-miniconda@v2
@@ -112,7 +120,7 @@ jobs:
         run: pre-commit run --all
 
       - name: Import GCS key for tests
-        run: echo "${{ secrets.GCR_RW_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
+        run: echo "${{ secrets.GAR_RW_PYTHON_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
 
       # TESTS (FAST and SLOW)
       - name: Run fast tests

--- a/.github/workflows/python_gdal_ci.yml
+++ b/.github/workflows/python_gdal_ci.yml
@@ -159,8 +159,8 @@ jobs:
         name: Run Stage 2 Tests
         run: | 
           echo "${{ secrets.TEST_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
-          if [ ${{ inputs.test_stage_2_use_pytest_xdist }} ]; then
-            pytest --durations=0 -m '"${{ inputs.test_stage_2_conditions }}"' -n auto --disable-warnings
+          if [ ${{ inputs.test_stage_1_use_pytest_xdist }} ]; then
+            pytest --durations=0 -m '${{ inputs.test_stage_1_conditions }}' -n auto --disable-warnings
           else
-            pytest --durations=0 -m '"${{ inputs.test_stage_2_conditions }}"' --disable-warnings
+            pytest --durations=0 -m '${{ inputs.test_stage_1_conditions }}' --disable-warnings
           fi

--- a/.github/workflows/python_gdal_ci.yml
+++ b/.github/workflows/python_gdal_ci.yml
@@ -145,10 +145,12 @@ jobs:
         run: pre-commit run --all
 
       # TESTS Stage 1 and Stage 2
+      - name: Import GCS key for tests
+        run: echo "${{ secrets.TEST_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
+
       - if: inputs.test_stage_1_should_run
         name: Run Stage 1 Tests
         run: | 
-          echo "${{ secrets.TEST_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
           if [ ${{ inputs.test_stage_1_use_pytest_xdist }} ]; then
             pytest --durations=0 -m '${{ inputs.test_stage_1_conditions }}' -n auto --disable-warnings
           else
@@ -158,7 +160,6 @@ jobs:
       - if: (inputs.test_stage_2_should_run) && (inputs.test_stage_2_run_in_branch || github.event_name == 'push')
         name: Run Stage 2 Tests
         run: | 
-          echo "${{ secrets.TEST_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
           if [ ${{ inputs.test_stage_2_use_pytest_xdist }} ]; then
             pytest --durations=0 -m '${{ inputs.test_stage_2_conditions }}' -n auto --disable-warnings
           else

--- a/.github/workflows/python_gdal_ci.yml
+++ b/.github/workflows/python_gdal_ci.yml
@@ -31,6 +31,13 @@ on:
         default: '1.5.1'
         required: false
         type: string
+
+      # Check SDK and package versions match
+      check_sdk_and_package_version_match:
+        description: 'Set to true to check if the SDK and main package have the same version number'
+        default: false
+        required: false
+        type: boolean
       
       # Testing arguments for two-stage tests 
       test_stage_1_should_run:
@@ -139,6 +146,18 @@ jobs:
           echo "${{ secrets.GAR_RW_PYTHON_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
           poetry self add keyrings-google-artifactregistry-auth==1.0.0
           poetry install
+
+      # ENSURE PACKAGE AND SDK HAVE THE SAME VERSION NUMBER
+      - if: inputs.check_sdk_and_package_version_match
+        name: Ensure SDK and package versions match
+        run: |
+          VERSION1=$(poetry version -s)
+          echo "${{ inputs.repository_name }}_sdk" | tr '-' '_' >> $SDK_DIRECTORY
+          VERSION2=$(cd $SDK_DIRECTORY && poetry version -s)
+          if [ "$VERSION1" != "$VERSION2" ]; then
+            echo "Package and SDK versions do not match"
+            exit 1
+          fi
 
       # FORMATTING
       - name: Run Pre-commit Hooks

--- a/.github/workflows/python_gdal_ci.yml
+++ b/.github/workflows/python_gdal_ci.yml
@@ -127,7 +127,7 @@ jobs:
         run: | 
           if ${{ inputs.use_pytest_xdist }}; then
             pytest --durations=0 -m '${{ inputs.pytest_fast_conditions }}' -n auto --disable-warnings
-          else then
+          else; then
             pytest --durations=0 -m '${{ inputs.pytest_fast_conditions }}' --disable-warnings
           fi
 
@@ -136,6 +136,6 @@ jobs:
         run: | 
           if ${{ inputs.use_pytest_xdist }}; then
             pytest --durations=0 -m '"${{ inputs.pytest_slow_conditions }}"' -n auto --disable-warnings
-          else then
+          else; then
             pytest --durations=0 -m '"${{ inputs.pytest_slow_conditions }}"' --disable-warnings
           fi

--- a/.github/workflows/python_gdal_ci.yml
+++ b/.github/workflows/python_gdal_ci.yml
@@ -5,12 +5,13 @@ name: CI pipeline for GDAL Python repositories
 # 2. poetry (pyproject.toml and poetry.lock files)
 # 3. repository name = conda env name = package name
 # 4. uses pre-commit hooks
-# 5. slow tests are run on push to main only, not in every CI run
-# 6. 
+# 5. two testing "stages": e.g. stage 1 = fast tests, stage 2 = slow tests, or stage 1 = parallel tests, stage 2 = dask tests
 
 on:
   workflow_call:
     inputs:
+
+      # Testing arguments for two-stage tests
       repository_name:
         description: 'Name of conda environment, python package'
         required: true
@@ -30,21 +31,45 @@ on:
         default: '1.5.1'
         required: false
         type: string
-      use_pytest_xdist:
-        description: 'Set to true of pytest-xdist is installed to run tests in parallel'
+      
+      # Testing arguments for two-stage tests 
+      test_stage_1_should_run:
+        description: 'Set to true to use the subsequent settings to run tests'
+        default: true
+        required: true
+        type: boolean
+      test_stage_1_use_pytest_xdist:
+        description: 'Set to true to use pytest-xdist to run stage 1 tests in parallel (expects pytext-xdist to be installed)'
         default: false
         required: false
         type: boolean
-      pytest_fast_conditions:
-        description: 'Conditions determining when fast tests should be run using pytest markers'
-        default: "not slow"
+      test_stage_1_conditions:
+        description: 'Pytest marker conditions for stage 1 tests'
+        default: ""
         required: false
         type: string
-      pytest_slow_conditions:
-        description: 'Conditions determining when slow tests should be run using pytest markers'
+
+      test_stage_2_should_run:
+        description: 'Set to true to use the subsequent settings to run tests'
+        default: false
+        required: false
+        type: boolean
+      test_stage_2_use_pytest_xdist:
+        description: 'Set to true if pytest-xdist to run stage 2 tests in parallel (expects pytext-xdist to be installed)'
+        default: false
+        required: false
+        type: boolean
+      test_stage_2_conditions:
+        description: 'Pytest marker conditions for stage 2 tests'
         default: "slow"
         required: false
         type: string
+      test_stage_2_run_in_branch:
+        description: 'Set to true if tests should be run for each PR iteration, or False for tests to only run when merged to main'
+        default: true
+        required: false
+        type: boolean
+
     secrets:
       GAR_RW_PYTHON_SERVICEACCOUNT_KEY:
         description: 'Service account key to access the registry for publishing artifacts'
@@ -119,22 +144,23 @@ jobs:
       - name: Run Pre-commit Hooks
         run: pre-commit run --all
 
-      # TESTS (FAST and SLOW)
-      - name: Run fast tests
+      # TESTS Stage 1 and Stage 2
+      - if: inputs.test_stage_1_should_run
+        name: Run Stage 1 Tests
         run: | 
           echo "${{ secrets.TEST_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
-          if [ ${{ inputs.use_pytest_xdist }} ]; then
-            pytest --durations=0 -m '${{ inputs.pytest_fast_conditions }}' -n auto --disable-warnings
+          if [ ${{ inputs.test_stage_1_use_pytest_xdist }} ]; then
+            pytest --durations=0 -m '${{ inputs.test_stage_1_conditions }}' -n auto --disable-warnings
           else
-            pytest --durations=0 -m '${{ inputs.pytest_fast_conditions }}' --disable-warnings
+            pytest --durations=0 -m '${{ inputs.test_stage_1_conditions }}' --disable-warnings
           fi
 
-      - if: github.event_name == 'push'
-        name: Run slow tests
+      - if: inputs.test_stage_2_should_run && github.event_name == 'push'
+        name: Run Stage 2 Tests
         run: | 
           echo "${{ secrets.TEST_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
-          if [ ${{ inputs.use_pytest_xdist }} ]; then
-            pytest --durations=0 -m '"${{ inputs.pytest_slow_conditions }}"' -n auto --disable-warnings
+          if [ ${{ inputs.test_stage_2_use_pytest_xdist }} ]; then
+            pytest --durations=0 -m '"${{ inputs.test_stage_2_conditions }}"' -n auto --disable-warnings
           else
-            pytest --durations=0 -m '"${{ inputs.pytest_slow_conditions }}"' --disable-warnings
+            pytest --durations=0 -m '"${{ inputs.test_stage_2_conditions }}"' --disable-warnings
           fi

--- a/.github/workflows/python_gdal_ci.yml
+++ b/.github/workflows/python_gdal_ci.yml
@@ -155,7 +155,7 @@ jobs:
             pytest --durations=0 -m '${{ inputs.test_stage_1_conditions }}' --disable-warnings
           fi
 
-      - if: inputs.test_stage_2_should_run && github.event_name == 'push'
+      - if: inputs.test_stage_2_should_run || github.event_name == 'push'
         name: Run Stage 2 Tests
         run: | 
           echo "${{ secrets.TEST_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS

--- a/.github/workflows/python_gdal_ci.yml
+++ b/.github/workflows/python_gdal_ci.yml
@@ -151,10 +151,9 @@ jobs:
       - if: inputs.check_sdk_and_package_version_match
         name: Ensure SDK and package versions match
         run: |
-          VERSION1=$(poetry version -s)
-          echo "SDK_DIRECTORY=${{ inputs.repository_name }}_sdk" | tr '-' '_' >> $GITHUB_ENV
-          VERSION2=$(cd ${{ env.SDK_DIRECTORY }} && poetry version -s)
-          if [ "$VERSION1" != "$VERSION2" ]; then
+          PACKAGE_VERSION=$(poetry version -s)
+          SDK_VERSION=$(cd $(echo ${{ inputs.repository_name }}"_sdk" | tr '-' '_') && poetry version -s)
+          if [ "$PACKAGE_VERSION" != "$SDK_VERSION" ]; then
             echo "Package and SDK versions do not match"
             exit 1
           fi

--- a/.github/workflows/python_gdal_ci.yml
+++ b/.github/workflows/python_gdal_ci.yml
@@ -160,7 +160,7 @@ jobs:
         run: | 
           echo "${{ secrets.TEST_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
           if [ ${{ inputs.test_stage_1_use_pytest_xdist }} ]; then
-            pytest --durations=0 -m '${{ inputs.test_stage_1_conditions }}' -n auto --disable-warnings
+            pytest --durations=0 -m '${{ inputs.test_stage_2_conditions }}' -n auto --disable-warnings
           else
-            pytest --durations=0 -m '${{ inputs.test_stage_1_conditions }}' --disable-warnings
+            pytest --durations=0 -m '${{ inputs.test_stage_2_conditions }}' --disable-warnings
           fi

--- a/.github/workflows/python_gdal_ci.yml
+++ b/.github/workflows/python_gdal_ci.yml
@@ -134,8 +134,8 @@ jobs:
       - if: github.event_name == 'push'
         name: Run slow tests
         run: | 
-          if ${{ inputs.use_pytest_xdist }}; then
+          if [ ${{ inputs.use_pytest_xdist }} ]; then
             pytest --durations=0 -m '"${{ inputs.pytest_slow_conditions }}"' -n auto --disable-warnings
-          else; then
+          else
             pytest --durations=0 -m '"${{ inputs.pytest_slow_conditions }}"' --disable-warnings
           fi

--- a/.github/workflows/python_gdal_ci.yml
+++ b/.github/workflows/python_gdal_ci.yml
@@ -152,8 +152,8 @@ jobs:
         name: Ensure SDK and package versions match
         run: |
           VERSION1=$(poetry version -s)
-          echo "${{ inputs.repository_name }}_sdk" | tr '-' '_' >> $SDK_DIRECTORY
-          VERSION2=$(cd $SDK_DIRECTORY && poetry version -s)
+          echo "SDK_DIRECTORY=${{ inputs.repository_name }}_sdk" | tr '-' '_' >> $GITHUB_ENV
+          VERSION2=$(cd ${{ env.SDK_DIRECTORY }} && poetry version -s)
           if [ "$VERSION1" != "$VERSION2" ]; then
             echo "Package and SDK versions do not match"
             exit 1

--- a/.github/workflows/python_gdal_ci.yml
+++ b/.github/workflows/python_gdal_ci.yml
@@ -1,25 +1,14 @@
 name: CI pipeline for GDAL Python repositories 
 
-## Assumptions
-# 1. conda env file is called env.yml
-# 2. poetry (pyproject.toml and poetry.lock files)
-# 3. repository name = conda env name = package name
-# 4. uses pre-commit hooks
-# 5. two testing "stages": e.g. stage 1 = fast tests, stage 2 = slow tests, or stage 1 = parallel tests, stage 2 = dask tests
 
 on:
   workflow_call:
     inputs:
 
-      # Testing arguments for two-stage tests
+      # Main parameters
       repository_name:
-        description: 'Name of conda environment, python package'
+        description: 'Name of repository conda environment, python package (with dashes, e.g. risk-score)'
         required: true
-        type: string
-      gdal_version:
-        description: 'version of GDAL being used e.g. 3.6.4'
-        default: '3.6.4'
-        required: false
         type: string
       python_version:
         description: 'Python version for building lib'
@@ -39,9 +28,9 @@ on:
         required: false
         type: boolean
       
-      # Testing arguments for two-stage tests 
+      # Testing arguments for Stage 1 tests 
       test_stage_1_should_run:
-        description: 'Set to true to run the stage 1 tests as defined below'
+        description: 'Set to true to run the stage 1 tests using the parameters that follow'
         default: true
         required: false
         type: boolean
@@ -56,13 +45,14 @@ on:
         required: false
         type: string
 
+      # Testing arguments for Stage 2 tests 
       test_stage_2_should_run:
-        description: 'Set to true to run the stage 2 tests as defined below'
+        description: 'Set to true to run the stage 2 tests using the parameters that follow'
         default: false
         required: false
         type: boolean
       test_stage_2_use_pytest_xdist:
-        description: 'Set to true if pytest-xdist to run stage 2 tests in parallel (expects pytext-xdist to be installed)'
+        description: 'Set to true to use pytest-xdist to run stage 2 tests in parallel (expects pytext-xdist to be installed)'
         default: false
         required: false
         type: boolean
@@ -83,7 +73,7 @@ on:
         required: true
       SSH_KEY:
         description: 'SSH key used to access private repos during the build'
-        required: true
+        required: false
       TEST_SERVICEACCOUNT_KEY:
         description: 'Service account key with access to resources needed for running tests'
         required: true

--- a/README.md
+++ b/README.md
@@ -220,3 +220,57 @@ This [workflow](./.github/workflows/python_library_ci.yml) will run precommit ho
 |    TEST_SERVICEACCOUNT_KEY     | Service account credentials to run the tests           |  false   |
 
 </details>
+
+## Run CI for Python GDAL Repository
+
+This [workflow](./.github/workflows/python_gdal_ci.yml) will run precommit hooks and tests for a GDAL-based python package.
+
+[Example workflow call](./examples/python_gdal_ci.yml)
+
+<details>
+  <summary>Workflow Input Variables</summary>
+
+|       name        | description                                                                                                               |  type   | default | required |
+| :---------------: | :------------------------------------------------------------------------------------------------------------------------ | :-----: | :------ | :------: |
+|  repository_name                    | Name of the python repository and conda environment                                                     | string  | None    |   true   |
+|  python_version                     | Python version to use when running CI                                                                   | string  | 3.10.6  |  false   |
+|  poetry_version                     | Poetry version to run and build package                                                                 | string  | 1.5.1   |  false   |
+| check_sdk_and_package_version_match | Check if SDK and package versions match                                                                 | boolean | false   |  false   |
+|  test_stage_1_should_run            | Set to true to run Stage 1 test                                                                         | boolean | true    |  false   |
+|  test_stage_1_use_pytest_xdist      | Set to true if Stage 1 tests should be run in parallel using `pytest-xdist` (needs to be installed)     | boolean | false   |  false   |
+|  test_stage_1_conditions            | Pytest marker conditions to include/exclude tests for Stage 1                                           | string  | ''      |  false   |
+|  test_stage_2_should_run            | Set to true to run Stage 2 test                                                                         | boolean | false   |  false   |
+|  test_stage_2_use_pytest_xdist      | Set to true if Stage 2 tests should be run in parallel using `pytest-xdist` (needs to be installed)     | boolean | false   |  false   |
+|  test_stage_2_conditions            | Pytest marker conditions to include/exclude tests for Stage 2                                           | string  | ''      |  false   |
+|  test_stage_2_run_in_branch         | Set to true to run Stage 2 test on each PR commit. Otherwise, Stage 2 is only run on merges to `main`   | boolean | true    |  false   |
+
+#### Input Secrets
+
+|              name                | description                                            | required |
+| :------------------------------: | :----------------------------------------------------- | :------: |
+| GAR_RW_PYTHON_SERVICEACCOUNT_KEY | Service account credentials to access GAR libraries    |   true   |
+|    SSH_KEY                       | SSH key used to access private repos during the build  |  false   |
+|    TEST_SERVICEACCOUNT_KEY       | Service account credentials to run the tests           |   true   |
+
+</details>
+
+
+### Workflow Assumptions
+
+To use this workflow, it is assumed that your repository conforms to the following structure and tooling:
+
+1. Uses `poetry` (`pyproject.toml` and `poetry.lock` files) and `conda`
+2. Conda environment file is called `env.yml`
+3. The repository name = conda env name = package name 
+4. If an SDK is present, the SDK folder = the repository name with "_sdk" appended e.g. `risk_score_sdk`
+5. Uses pre-commit hooks to run linting, formatting
+6. Two testing stages which can be used in different ways
+     Example Use-Case 1:
+        Test Stage 1 runs all tests 
+        Test Stage 2 skipped
+     Example Use-Case 2:
+        Test Stage 1 runs fast tests
+        Test stage 2 runs slow tests 
+     Example Use-Case 3: 
+        Test stage 1 for parallel tests using pytext-xdist
+        Test stage 2 to run Dask tests without pytext-xdist (to avoid parallel-conflicts)

--- a/README.md
+++ b/README.md
@@ -246,11 +246,11 @@ This [workflow](./.github/workflows/python_gdal_ci.yml) will run precommit hooks
 
 #### Input Secrets
 
-|              name                | description                                            | required |
-| :------------------------------: | :----------------------------------------------------- | :------: |
-| GAR_RW_PYTHON_SERVICEACCOUNT_KEY | Service account credentials to access GAR libraries    |   true   |
-|    SSH_KEY                       | SSH key used to access private repos during the build  |  false   |
-|    TEST_SERVICEACCOUNT_KEY       | Service account credentials to run the tests           |   true   |
+|              name                | description                                              | required |
+| :------------------------------: | :------------------------------------------------------- | :------: |
+|  REGISTRY_RW_SERVICEACCOUNT_KEY  | Service account credentials to access registry libraries |   true   |
+|    SSH_KEY                       | SSH key used to access private repos during the build    |  false   |
+|    TEST_SERVICEACCOUNT_KEY       | Service account credentials to run the tests             |   true   |
 
 </details>
 

--- a/examples/python_gdal_ci.yml
+++ b/examples/python_gdal_ci.yml
@@ -1,0 +1,28 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  ci:
+    uses: 20treeAI/github-workflows/.github/workflows/python_gdal_ci.yml@main
+    with:
+      repository_name: 'my-gdal-python-repo'
+      gdal_version: '3.6.4'
+      python_version: '3.10.6'
+      poetry_version: '1.5.1'
+      check_sdk_and_package_version_match: true
+      test_stage_1_should_run: true
+      test_stage_1_use_pytest_xdist: true
+      test_stage_1_conditions: 'not db and not dask'
+      test_stage_2_should_run: true
+      test_stage_2_use_pytest_xdist: false
+      test_stage_2_conditions: 'not db and dask'
+    secrets:
+      GAR_RW_PYTHON_SERVICEACCOUNT_KEY: ${{ secrets.GAR_RW_PYTHON_SERVICEACCOUNT_KEY }}
+      SSH_KEY: ${{ secrets.OVERSTORY_BOT_SSH_KEY }}
+      TEST_SERVICEACCOUNT_KEY: ${{ secrets.GCR_RW_SERVICEACCOUNT_KEY }}
+      

--- a/examples/python_gdal_ci.yml
+++ b/examples/python_gdal_ci.yml
@@ -11,9 +11,6 @@ jobs:
     uses: 20treeAI/github-workflows/.github/workflows/python_gdal_ci.yml@main
     with:
       repository_name: 'my-gdal-python-repo'
-      gdal_version: '3.6.4'
-      python_version: '3.10.6'
-      poetry_version: '1.5.1'
       check_sdk_and_package_version_match: true
       test_stage_1_should_run: true
       test_stage_1_use_pytest_xdist: true
@@ -25,4 +22,3 @@ jobs:
       GAR_RW_PYTHON_SERVICEACCOUNT_KEY: ${{ secrets.GAR_RW_PYTHON_SERVICEACCOUNT_KEY }}
       SSH_KEY: ${{ secrets.OVERSTORY_BOT_SSH_KEY }}
       TEST_SERVICEACCOUNT_KEY: ${{ secrets.GCR_RW_SERVICEACCOUNT_KEY }}
-      

--- a/examples/python_gdal_ci.yml
+++ b/examples/python_gdal_ci.yml
@@ -19,6 +19,5 @@ jobs:
       test_stage_2_use_pytest_xdist: false
       test_stage_2_conditions: 'not db and dask'
     secrets:
-      GAR_RW_PYTHON_SERVICEACCOUNT_KEY: ${{ secrets.GAR_RW_PYTHON_SERVICEACCOUNT_KEY }}
+      REGISTRY_RW_SERVICEACCOUNT_KEY: ${{ secrets.REGISTRY_RW_SERVICEACCOUNT_KEY }}
       SSH_KEY: ${{ secrets.OVERSTORY_BOT_SSH_KEY }}
-      TEST_SERVICEACCOUNT_KEY: ${{ secrets.GCR_RW_SERVICEACCOUNT_KEY }}


### PR DESCRIPTION
### Changes

Adding a shared workflow for usage in our GDAL python repositories.

### Motivation

Adding improvements e.g. caching, clarifying docs, new features take a lot of time because each GDAL python repo has their own, hardcoded CI workflow.

### Notable Features

- **Check SDK and package version match**
   Flag which tests if the SDK version and package version match (`poetry version -s`)
- **2 Test "Stages"**
    
    Ability to run two individual sets of test combinations. 

    Examples of where these two stages are useful:
    - Run stage 1 (fast) tests in CI on each commit, stage 2 (slow) tests only on merge to `main` (currently needed in`data-ingestion`, `coregistration` and `image-inventory`)
    - Run stage 1 (parallel) tests in parallel using `pytest-xdist` and stage 2 (dask) tests sequentially to avoid conflicts between `dask` and `pytest-xdist` (currently needed in `risk-score`)

### Scope of this PR

1. Create workflow to be used in multiple GDAL/Python repositories

2. Test this workflow on the following repositories:

    - [x] risk-score: https://github.com/20treeAI/risk_score/pull/411
    - [x] data-ingestion: https://github.com/20treeAI/data-ingestion/pull/539
    - [x] coregistration: https://github.com/20treeAI/coregistration/pull/155
    - [x] image-inventory: https://github.com/20treeAI/image-inventory/pull/86
