### PR TITLE
ci: refactor, bump versions

### DIFF
--- a/.github/workflows/deploy_mkdocs.yml
+++ b/.github/workflows/deploy_mkdocs.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python_version }}
 

--- a/.github/workflows/python_gdal_ci.yml
+++ b/.github/workflows/python_gdal_ci.yml
@@ -101,7 +101,7 @@ jobs:
           ssh-add - <<< "${{ secrets.SSH_KEY }}"
 
       # CONDA
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-variant: Mambaforge
           use-mamba: true

--- a/.github/workflows/python_gdal_ci.yml
+++ b/.github/workflows/python_gdal_ci.yml
@@ -106,7 +106,7 @@ jobs:
           miniforge-variant: Mambaforge
           miniforge-version: latest
           use-mamba: true
-          activate-environment: ${{ inputs.repository_name }}
+          activate-environment: ci-env
 
         # Save the conda environment to cache.
         # NOTE automatically invalidates cache monthly OR on any change of the env.yml or poetry.lock files
@@ -117,13 +117,13 @@ jobs:
         uses: actions/cache@v4
         id: conda-env-cache
         with:
-          path: /usr/share/miniconda3/envs/${{ inputs.repository_name }}
+          path: /usr/share/miniconda3/envs/ci-env
           key: conda-${{ env.MONTH }}-${{ hashFiles('env.yml') }}-${{ hashFiles('poetry.lock') }}
 
         # Only install conda packages if the cache is invalidated
       - name: Install conda packages
         if: steps.conda-env-cache.outputs.cache-hit != 'true'
-        run: mamba env update -n ${{ inputs.repository_name }} -f env.yml
+        run: mamba env update -n ci-env -f env.yml
 
       - name: Install poetry
         uses: snok/install-poetry@v1

--- a/.github/workflows/python_gdal_ci.yml
+++ b/.github/workflows/python_gdal_ci.yml
@@ -93,7 +93,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # NOTE: This must run before the env restore, changed LD_LIBRARY_PATH can cause OpenSSL mismatch errors
       - name: Setup SSH Keys and known_hosts
         run: |
           mkdir -p ~/.ssh
@@ -106,6 +105,7 @@ jobs:
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest
+          use-mamba: true
           activate-environment: ${{ inputs.repository_name }}
 
         # Save the conda environment to cache.

--- a/.github/workflows/python_gdal_ci.yml
+++ b/.github/workflows/python_gdal_ci.yml
@@ -91,7 +91,7 @@ jobs:
         shell: bash -el {0}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # NOTE: This must run before the env restore, changed LD_LIBRARY_PATH can cause OpenSSL mismatch errors
       - name: Setup SSH Keys and known_hosts
@@ -102,7 +102,7 @@ jobs:
           ssh-add - <<< "${{ secrets.SSH_KEY }}"
 
       # CONDA
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest
@@ -114,7 +114,7 @@ jobs:
       - name: Save date for cache keys
         run: echo "MONTH=$(date +'%Y%m')" >> $GITHUB_ENV 
       - name: Cache Conda env
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: conda-env-cache
         with:
           path: /usr/share/miniconda3/envs/${{ inputs.repository_name }}

--- a/.github/workflows/python_gdal_ci.yml
+++ b/.github/workflows/python_gdal_ci.yml
@@ -17,7 +17,7 @@ on:
         type: string
       poetry_version:
         description: 'Poetry version for building lib'
-        default: '1.5.1'
+        default: '1.7.1'
         required: false
         type: string
 
@@ -134,7 +134,7 @@ jobs:
       - name: Install package
         run: |
           echo "${{ secrets.REGISTRY_RW_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
-          poetry self add keyrings-google-artifactregistry-auth==1.0.0
+          poetry self add keyrings-google-artifactregistry-auth
           poetry install
 
       # ENSURE PACKAGE AND SDK HAVE THE SAME VERSION NUMBER

--- a/.github/workflows/python_gdal_ci.yml
+++ b/.github/workflows/python_gdal_ci.yml
@@ -101,7 +101,7 @@ jobs:
           ssh-add - <<< "${{ secrets.SSH_KEY }}"
 
       # CONDA
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: conda-incubator/setup-miniconda@v2
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest

--- a/.github/workflows/python_gdal_ci.yml
+++ b/.github/workflows/python_gdal_ci.yml
@@ -113,9 +113,9 @@ jobs:
           use-mamba: true
           activate-environment: ci-env
 
-        # Save the conda environment to cache.
-        # NOTE automatically invalidates cache monthly OR on any change of the env.yml or poetry.lock files
-        # Edit this portion to adjust cache "lifetime"
+      # Save the conda environment to cache.
+      # Invalidates cache monthly OR on any change of the env.yml or poetry.lock files.
+      # Edit this portion to adjust cache lifetime.
       - name: Save date for cache keys
         run: echo "MONTH=$(date +'%Y%m')" >> $GITHUB_ENV 
       - name: Cache Conda env

--- a/.github/workflows/python_gdal_ci.yml
+++ b/.github/workflows/python_gdal_ci.yml
@@ -104,7 +104,6 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniforge-variant: Mambaforge
-          miniforge-version: latest
           use-mamba: true
           activate-environment: ci-env
 
@@ -117,7 +116,7 @@ jobs:
         uses: actions/cache@v4
         id: conda-env-cache
         with:
-          path: /usr/share/miniconda3/envs/ci-env
+          path: /home/runner/miniconda3/envs/ci-env
           key: conda-${{ env.MONTH }}-${{ hashFiles('env.yml') }}-${{ hashFiles('poetry.lock') }}
 
         # Only install conda packages if the cache is invalidated

--- a/.github/workflows/python_gdal_ci.yml
+++ b/.github/workflows/python_gdal_ci.yml
@@ -66,6 +66,11 @@ on:
         default: true
         required: false
         type: boolean
+      provide_ssh_access:
+        description: 'Set to true if the project has packages installed using ssh'
+        default: false
+        required: false
+        type: boolean
 
     secrets:
       REGISTRY_RW_SERVICEACCOUNT_KEY:
@@ -94,6 +99,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup SSH Keys and known_hosts
+        if: inputs.provide_ssh_access
         run: |
           mkdir -p ~/.ssh
           ssh-keyscan github.com >> ~/.ssh/known_hosts
@@ -131,6 +137,7 @@ jobs:
 
       # POETRY INSTALL
       - name: Install package
+        if: steps.conda-env-cache.outputs.cache-hit != 'true'
         run: |
           echo "${{ secrets.REGISTRY_RW_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
           poetry self add keyrings-google-artifactregistry-auth

--- a/.github/workflows/python_library_ci.yml
+++ b/.github/workflows/python_library_ci.yml
@@ -88,7 +88,7 @@ jobs:
         uses: actions/cache@v4
         id: conda-env-cache
         with:
-          path: /runner/home/miniconda3/envs/ci-env
+          path: /home/runner/miniconda3/envs/ci-env
           key: conda-${{ env.MONTH }}-${{ hashFiles('env.yml') }}-${{ hashFiles('poetry.lock') }}
 
       # Only install conda packages if the cache is invalidated

--- a/.github/workflows/python_library_ci.yml
+++ b/.github/workflows/python_library_ci.yml
@@ -66,13 +66,13 @@ jobs:
           python-version: ${{ inputs.python_version }}
 
         - uses: conda-incubator/setup-miniconda@v3
-        if: inputs.conda_env_file != ''
-        with:
-          activate-environment: ci-env
-          miniforge-variant: Mambaforge
-          use-mamba: true
-          environment-file: ${{ inputs.conda_env_file }}
-
+          if: inputs.conda_env_file != ''
+          with:
+            activate-environment: ci-env
+            miniforge-variant: Mambaforge
+            use-mamba: true
+            environment-file: ${{ inputs.conda_env_file }}
+             
       - name: Setup SSH Keys and known_hosts
         if: inputs.provide_ssh_access
         run: |
@@ -80,6 +80,23 @@ jobs:
           ssh-keyscan github.com >> ~/.ssh/known_hosts
           ssh-agent -a $SSH_AUTH_SOCK > /dev/null
           ssh-add - <<< "${{ secrets.SSH_KEY }}"
+
+      # Save the conda environment to cache.
+      # Invalidates cache monthly OR on any change of the env.yml or poetry.lock files
+      # Edit this portion to adjust cache "lifetime"
+      - name: Save date for cache keys
+        run: echo "MONTH=$(date +'%Y%m')" >> $GITHUB_ENV 
+      - name: Cache Conda env
+        uses: actions/cache@v4
+        id: conda-env-cache
+        with:
+          path: /usr/share/miniconda3/envs/${{ inputs.repository_name }}
+          key: conda-${{ env.MONTH }}-${{ hashFiles('env.yml') }}-${{ hashFiles('poetry.lock') }}
+
+      # Only install conda packages if the cache is invalidated
+      - name: Install conda packages
+        if: steps.conda-env-cache.outputs.cache-hit != 'true'
+        run: mamba env update -n ${{ inputs.repository_name }} -f env.yml
 
       - name: Install poetry
         uses: snok/install-poetry@v1

--- a/.github/workflows/python_library_ci.yml
+++ b/.github/workflows/python_library_ci.yml
@@ -36,6 +36,12 @@ on:
         default: false
         required: false
         type: boolean
+      use_pytest_xdist:
+        description: 'Run tests in parallel using (expects pytext-xdist to be installed)'
+        default: false
+        required: false
+        type: boolean
+
     secrets:
       REGISTRY_RW_SERVICEACCOUNT_KEY:
         description: 'Service account key to access the registry for publishing artifacts'
@@ -114,7 +120,12 @@ jobs:
       - name: Run tests
         run: |
           echo "${{ secrets.TEST_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
-          poetry run pytest --disable-warnings --durations=0
+          if [ ${{ inputs.use_pytest_xdist }} ]; then
+            poetry run pytest --disable-warnings --durations=0 -n auto
+          else
+            poetry run pytest --disable-warnings --durations=0
+          fi
+       
 
       - name: Publish library
         if: github.event_name == 'release'

--- a/.github/workflows/python_library_ci.yml
+++ b/.github/workflows/python_library_ci.yml
@@ -65,14 +65,14 @@ jobs:
         with:
           python-version: ${{ inputs.python_version }}
 
-        - uses: conda-incubator/setup-miniconda@v3
-          if: inputs.conda_env_file != ''
-          with:
-            activate-environment: ci-env
-            miniforge-variant: Mambaforge
-            use-mamba: true
-            environment-file: ${{ inputs.conda_env_file }}
-             
+      - uses: conda-incubator/setup-miniconda@v3
+        if: inputs.conda_env_file != ''
+        with:
+          activate-environment: ci-env
+          miniforge-variant: Mambaforge
+          use-mamba: true
+          environment-file: ${{ inputs.conda_env_file }}
+            
       - name: Setup SSH Keys and known_hosts
         if: inputs.provide_ssh_access
         run: |

--- a/.github/workflows/python_library_ci.yml
+++ b/.github/workflows/python_library_ci.yml
@@ -116,7 +116,8 @@ jobs:
       - name: Run tests
         run: |
           echo "${{ secrets.TEST_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
-          poetry run pytest --disable-warnings
+          poetry add pytest-xdist
+          poetry run pytest --disable-warnings -n auto --durations=0
 
       - name: Publish library
         if: github.event_name == 'release'

--- a/.github/workflows/python_library_ci.yml
+++ b/.github/workflows/python_library_ci.yml
@@ -90,13 +90,13 @@ jobs:
         uses: actions/cache@v4
         id: conda-env-cache
         with:
-          path: /usr/share/miniconda3/envs/${{ inputs.repository_name }}
+          path: /usr/share/miniconda3/envs/ci-env
           key: conda-${{ env.MONTH }}-${{ hashFiles('env.yml') }}-${{ hashFiles('poetry.lock') }}
 
       # Only install conda packages if the cache is invalidated
       - name: Install conda packages
         if: steps.conda-env-cache.outputs.cache-hit != 'true'
-        run: mamba env update -n ${{ inputs.repository_name }} -f env.yml
+        run: mamba env update -n ci-env -f env.yml
 
       - name: Install poetry
         uses: snok/install-poetry@v1

--- a/.github/workflows/python_library_ci.yml
+++ b/.github/workflows/python_library_ci.yml
@@ -66,12 +66,10 @@ jobs:
           python-version: ${{ inputs.python_version }}
 
       - uses: conda-incubator/setup-miniconda@v2
-        if: inputs.conda_env_file != ''
         with:
-          activate-environment: ci-env
           miniforge-variant: Mambaforge
           use-mamba: true
-          environment-file: ${{ inputs.conda_env_file }}
+          activate-environment: ci-env
             
       - name: Setup SSH Keys and known_hosts
         if: inputs.provide_ssh_access
@@ -90,7 +88,7 @@ jobs:
         uses: actions/cache@v4
         id: conda-env-cache
         with:
-          path: /usr/share/miniconda3/envs/ci-env
+          path: /runner/home/miniconda3/envs/ci-env
           key: conda-${{ env.MONTH }}-${{ hashFiles('env.yml') }}-${{ hashFiles('poetry.lock') }}
 
       # Only install conda packages if the cache is invalidated

--- a/.github/workflows/python_library_ci.yml
+++ b/.github/workflows/python_library_ci.yml
@@ -60,12 +60,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         if: inputs.conda_env_file == ''
         with:
           python-version: ${{ inputs.python_version }}
 
-      - uses: conda-incubator/setup-miniconda@v2
+        - uses: conda-incubator/setup-miniconda@v3
         if: inputs.conda_env_file != ''
         with:
           activate-environment: ci-env

--- a/.github/workflows/python_library_ci.yml
+++ b/.github/workflows/python_library_ci.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           python-version: ${{ inputs.python_version }}
 
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: conda-incubator/setup-miniconda@v2
         if: inputs.conda_env_file != ''
         with:
           activate-environment: ci-env

--- a/.github/workflows/python_library_ci.yml
+++ b/.github/workflows/python_library_ci.yml
@@ -19,7 +19,7 @@ on:
         type: string
       poetry_version:
         description: 'Poetry version for building lib'
-        default: '1.5.1'
+        default: '1.7.1'
         required: false
         type: string
       working_directory:
@@ -87,9 +87,10 @@ jobs:
           version: '${{ inputs.poetry_version }}'
 
       - name: Install package
+        if: steps.conda-env-cache.outputs.cache-hit != 'true'
         run: |
           echo "${{ secrets.REGISTRY_RW_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
-          poetry self add keyrings-google-artifactregistry-auth==1.0.0
+          poetry self add keyrings-google-artifactregistry-auth
           poetry install
 
       - name: Linting

--- a/.github/workflows/python_library_ci.yml
+++ b/.github/workflows/python_library_ci.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           python-version: ${{ inputs.python_version }}
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-variant: Mambaforge
           use-mamba: true
@@ -107,7 +107,6 @@ jobs:
           echo "${{ secrets.REGISTRY_RW_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
           poetry self add keyrings-google-artifactregistry-auth
           poetry install
-          poetry add pytest-xdist
 
       - name: Linting
         run: poetry run pre-commit run --files ${{ inputs.working_directory }}/**/*
@@ -115,7 +114,7 @@ jobs:
       - name: Run tests
         run: |
           echo "${{ secrets.TEST_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
-          poetry run pytest --disable-warnings -n auto --durations=0
+          poetry run pytest --disable-warnings --durations=0
 
       - name: Publish library
         if: github.event_name == 'release'

--- a/.github/workflows/python_library_ci.yml
+++ b/.github/workflows/python_library_ci.yml
@@ -107,6 +107,7 @@ jobs:
           echo "${{ secrets.REGISTRY_RW_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
           poetry self add keyrings-google-artifactregistry-auth
           poetry install
+          poetry add pytest-xdist
 
       - name: Linting
         run: poetry run pre-commit run --files ${{ inputs.working_directory }}/**/*
@@ -114,7 +115,6 @@ jobs:
       - name: Run tests
         run: |
           echo "${{ secrets.TEST_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
-          poetry add pytest-xdist
           poetry run pytest --disable-warnings -n auto --durations=0
 
       - name: Publish library

--- a/.github/workflows/python_library_ci.yml
+++ b/.github/workflows/python_library_ci.yml
@@ -70,7 +70,7 @@ jobs:
           miniforge-variant: Mambaforge
           use-mamba: true
           activate-environment: ci-env
-            
+
       - name: Setup SSH Keys and known_hosts
         if: inputs.provide_ssh_access
         run: |

--- a/.github/workflows/python_library_ci.yml
+++ b/.github/workflows/python_library_ci.yml
@@ -80,8 +80,8 @@ jobs:
           ssh-add - <<< "${{ secrets.SSH_KEY }}"
 
       # Save the conda environment to cache.
-      # Invalidates cache monthly OR on any change of the env.yml or poetry.lock files
-      # Edit this portion to adjust cache "lifetime"
+      # Invalidates cache monthly OR on any change of the env.yml or poetry.lock files.
+      # Edit this portion to adjust cache lifetime.
       - name: Save date for cache keys
         run: echo "MONTH=$(date +'%Y%m')" >> $GITHUB_ENV 
       - name: Cache Conda env

--- a/.github/workflows/yarn_build_test.yml
+++ b/.github/workflows/yarn_build_test.yml
@@ -22,7 +22,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}


### PR DESCRIPTION
* bumps action versions
* bumps poetry version
* enables cache for libraries
* enables conditional disable for ssh and package install
* default env install location changed to /home/runner/miniconda3

lib test: https://github.com/20treeAI/geozarr/pull/131
gdal test: https://github.com/20treeAI/coregistration/pull/172

Downstream something might break if it does not have "provide_ssh_access" set.