### PR TITLE
Fix python CI workflow to support optional conda setup

### DIFF
--- a/.github/workflows/python_library_ci.yml
+++ b/.github/workflows/python_library_ci.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Run tests
         run: |
           echo "${{ secrets.TEST_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
-          if [ ${{ inputs.use_pytest_xdist }} ]; then
+          if [ ${{ inputs.use_pytest_xdist }} != "false" ]; then
             poetry run pytest --disable-warnings --durations=0 -n auto
           else
             poetry run pytest --disable-warnings --durations=0

--- a/.github/workflows/python_library_ci.yml
+++ b/.github/workflows/python_library_ci.yml
@@ -72,6 +72,7 @@ jobs:
           python-version: ${{ inputs.python_version }}
 
       - uses: conda-incubator/setup-miniconda@v3
+        if: inputs.conda_env_file != ''
         with:
           miniforge-variant: Mambaforge
           use-mamba: true
@@ -89,8 +90,10 @@ jobs:
       # Invalidates cache monthly OR on any change of the env.yml or poetry.lock files.
       # Edit this portion to adjust cache lifetime.
       - name: Save date for cache keys
+        if: inputs.conda_env_file != ''
         run: echo "MONTH=$(date +'%Y%m')" >> $GITHUB_ENV 
       - name: Cache Conda env
+        if: inputs.conda_env_file != ''
         uses: actions/cache@v4
         id: conda-env-cache
         with:
@@ -99,7 +102,7 @@ jobs:
 
       # Only install conda packages if the cache is invalidated
       - name: Install conda packages
-        if: steps.conda-env-cache.outputs.cache-hit != 'true'
+        if: inputs.conda_env_file != '' && steps.conda-env-cache.outputs.cache-hit != 'true'
         run: mamba env update -n ci-env -f env.yml
 
       - name: Install poetry
@@ -108,7 +111,7 @@ jobs:
           version: '${{ inputs.poetry_version }}'
 
       - name: Install package
-        if: steps.conda-env-cache.outputs.cache-hit != 'true'
+        if: inputs.conda_env_file == '' || steps.conda-env-cache.outputs.cache-hit != 'true'
         run: |
           echo "${{ secrets.REGISTRY_RW_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
           poetry self add keyrings-google-artifactregistry-auth

--- a/.github/workflows/python_library_ci.yml
+++ b/.github/workflows/python_library_ci.yml
@@ -103,7 +103,7 @@ jobs:
       # Only install conda packages if the cache is invalidated
       - name: Install conda packages
         if: inputs.conda_env_file != '' && steps.conda-env-cache.outputs.cache-hit != 'true'
-        run: mamba env update -n ci-env -f env.yml
+        run: mamba env update -n ci-env -f ${{ inputs.conda_env_file }}
 
       - name: Install poetry
         uses: snok/install-poetry@v1


### PR DESCRIPTION
* Include conditionals in workflow steps that use conda so non-conda repos skip those steps
* Fix pytest conditional when xdist is not enabled
* Use conda env input when building conda env