### PR TITLE
Update python_library_ci.yml

### DIFF
--- a/.github/workflows/python_library_ci.yml
+++ b/.github/workflows/python_library_ci.yml
@@ -140,5 +140,6 @@ jobs:
             exit 1
           fi
           echo "${{ secrets.REGISTRY_RW_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
+          poetry self add keyrings-google-artifactregistry-auth
           poetry config repositories.custom ${{ inputs.repo_uri }}
           poetry publish --build -r custom


### PR DESCRIPTION
When dependencies are cached, the `Install package` step is not run, which means the `poetry self add keyrings-google-artifactregistry-auth` is not called.

This causes a 401 when trying to publish the package in the `Publish library` step.

![image](https://github.com/20treeAI/github-workflows/assets/16143344/730a8189-ac44-4aae-a12f-77a9f662202f)


Original thread: https://20treeai.slack.com/archives/C018XVA73SL/p1706523957021629