### PR TITLE
Speed up GDAL shared workflow

### DIFF
--- a/.github/workflows/python_gdal_ci.yml
+++ b/.github/workflows/python_gdal_ci.yml
@@ -140,7 +140,7 @@ jobs:
         if: steps.conda-env-cache.outputs.cache-hit != 'true'
         run: |
           echo "${{ secrets.REGISTRY_RW_SERVICEACCOUNT_KEY }}" | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
-          poetry self add keyrings-google-artifactregistry-auth
+          poetry self add keyrings-google-artifactregistry-auth==1.1.2
           poetry install
 
       # ENSURE PACKAGE AND SDK HAVE THE SAME VERSION NUMBER


### PR DESCRIPTION
Speed up CI by pinning `poetry self add keyrings-google-artifactregistry-auth==1.1.2`

* With `poetry self add keyrings-google-artifactregistry-auth`: 11-15 min 
* With `poetry self add keyrings-google-artifactregistry-auth==1.1.2`: 1 min