### PR TITLE
fix/docker layer caching

### DIFF
--- a/.github/workflows/dagster.yml
+++ b/.github/workflows/dagster.yml
@@ -75,7 +75,7 @@ jobs:
     # only run on synchronize PR event, meaning something has been pushed to the PR branch
     if: github.event_name == 'push' || contains(fromJSON('["opened", "synchronize", "reopened", "push"]'), github.event.action) || (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'dev-env')
     # query our reusable docker build and push workflow
-    uses: 20treeAI/github-workflows/.github/workflows/docker_build_push.yml@fix/docker_caching
+    uses: 20treeAI/github-workflows/.github/workflows/docker_build_push.yml@main
     with:
       image_name: ${{ inputs.image_name }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/dagster.yml
+++ b/.github/workflows/dagster.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: "docker-container"
         type: string
+      clear_space:
+        description: 'Whether to clear some space on the runner, e.g. for large (CUDA) builds'
+        required: false
+        default: false
+        type: boolean
       gcp_project:
         description: "GCP project where GKE/GAR are located for storing built Docker images"
         required: true
@@ -70,13 +75,14 @@ jobs:
     # only run on synchronize PR event, meaning something has been pushed to the PR branch
     if: github.event_name == 'push' || contains(fromJSON('["opened", "synchronize", "reopened", "push"]'), github.event.action) || (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'dev-env')
     # query our reusable docker build and push workflow
-    uses: 20treeAI/github-workflows/.github/workflows/docker_build_push.yml@main
+    uses: 20treeAI/github-workflows/.github/workflows/docker_build_push.yml@fix/docker_caching
     with:
       image_name: ${{ inputs.image_name }}
       branch: ${{ inputs.branch }}
       gcp_project: ${{ inputs.gcp_project }}
       test_dagster: true
       docker_buildx_driver: ${{ inputs.docker_buildx_driver }}
+      clear_space: ${{ inputs.clear_space  }}
     secrets:
       SSH_KEY: ${{ secrets.SSH_KEY }}
       GCR_RW_SERVICEACCOUNT_KEY: ${{ secrets.GCR_RW_SERVICEACCOUNT_KEY }}

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -41,6 +41,11 @@ on:
         required: false
         default: 'docker-container'
         type: string
+      clear_space:
+        description: 'Whether to clear some space on the runner, e.g. for large (CUDA) builds'
+        required: false
+        default: false
+        type: boolean
 
     secrets:
       SSH_KEY:
@@ -60,6 +65,28 @@ jobs:
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     steps:
+      - name: Clear some space  # https://github.com/apache/flink/blob/master/tools/azure-pipelines/free_disk_space.sh
+        if: ${{ inputs.clear_space }}
+        run: |
+          df -h
+          # sudo apt remove -y '^dotnet-.*'
+          # sudo apt remove -y '^llvm-.*'
+          # sudo apt remove -y '^mongodb-.*'
+          # sudo apt remove -y '^mysql-.*'
+          sudo apt remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
+          sudo apt autoremove -y
+          sudo apt clean
+          df -h
+          # echo "Removing large directories"
+          # sudo rm -rf /usr/share/dotnet/
+          # sudo rm -rf /usr/local/graalvm/
+          # sudo rm -rf /usr/local/.ghcup/
+          # sudo rm -rf /usr/local/share/powershell
+          # sudo rm -rf /usr/local/share/chromium
+          # sudo rm -rf /usr/local/lib/android
+          # sudo rm -rf /usr/local/lib/node_modules
+          df -h
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -84,9 +111,19 @@ jobs:
           name: ${{ inputs.artifacts_object_name }}
           path: ${{ inputs.artifacts_path }}
 
-      - name: Set up Docker Buildx
-        id: buildx-setup
-        uses: docker/setup-buildx-action@v2.10.0
+      - name: Set up docker  # latest docker version to make driver: docker work with gha cache
+        uses: crazy-max/ghaction-setup-docker@v3
+        with:
+          version: latest
+          daemon-config: |
+            {
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
+
+      - name: Set up Docker Buildx 
+        uses: docker/setup-buildx-action@v3
         with:
           driver: ${{ inputs.docker_buildx_driver }}
 
@@ -101,27 +138,21 @@ jobs:
       - name: Use glcoud CLI to configure-docker auth
         run: gcloud auth configure-docker eu.gcr.io,europe-west4-docker.pkg.dev
 
-      - name: print driver
-        run: |
-         echo ${{ inputs.docker_buildx_driver }}
-         echo ${{ steps.buildx-setup.driver }}
-         echo ${{ steps.buildx-setup.driver == 'docker-container' && 'type=gha,mode=max' || 's' }}
-
       - if: ${{ inputs.test_dagster }}
         name: Build docker image
-        uses: docker/build-push-action@v4.1.1
+        uses: docker/build-push-action@v5
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         with:
           context: .
-          load: true
-          tags: test-image
-          ssh: default
+          load: ${{ inputs.docker_buildx_driver == 'docker-container' && true || false }}
+          push: false
+          tags: ${{ env.IMAGE_NAME }}/branch/${{ github.head_ref}}:test  # note that this is not image_name:head_ref to allow for / in the branch name!
           build-args: "GIT_COMMIT=${{ github.sha }}"
           secret-files: BUILD_KEY=/tmp/build_key.json
           provenance: false
           cache-from: type=gha
-          cache-to: ${{ steps.buildx-setup.driver == 'docker-container' && 'type=gha,mode=max' || 's' }}
+          cache-to: type=gha,mode=max
 
       - if: ${{ inputs.test_dagster }}
         name: Find repository.py file
@@ -131,7 +162,7 @@ jobs:
       - if: ${{ inputs.test_dagster }}
         name: Test Dagster Docker image
         run: |
-          docker run -p 8080:8080 -d --env 'TZ=Europe/Brussels' --name test_container test-image \
+          docker run -p 8080:8080 -d --env 'TZ=Europe/Brussels' --name test_container ${{ env.IMAGE_NAME }}/branch/${{ github.head_ref }}:test \
               dagster api grpc -h 0.0.0.0 -p 8080 --python-file "/dagster/${{ steps.find_repo_file.outputs.REPOSITORY_PY_LOCATION }}"
           sleep 5
           wget -O/tmp/grpc_health_probe -q https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.11/grpc_health_probe-linux-amd64
@@ -141,7 +172,7 @@ jobs:
       - name: Push docker image
         # if either a tag isn't provided, or if the run is scheduled (using automatic docker re-builds) for security
         if: ${{ !startsWith(github.ref, 'refs/tags/') || github.event_name == 'scheduled' }}
-        uses: docker/build-push-action@v4.1.1
+        uses: docker/build-push-action@v5
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         with:

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -150,6 +150,7 @@ jobs:
           load: ${{ inputs.docker_buildx_driver == 'docker-container' && true || false }}
           push: false
           tags: test-image
+          ssh: default
           build-args: "GIT_COMMIT=${{ github.sha }}"
           secret-files: BUILD_KEY=/tmp/build_key.json
           provenance: false

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -149,7 +149,7 @@ jobs:
           context: .
           load: ${{ inputs.docker_buildx_driver == 'docker-container' && true || false }}
           push: false
-          tags: ${{ env.IMAGE_NAME }}/branch/${{ github.head_ref}}:test  # note that this is not image_name:head_ref to allow for / in the branch name!
+          tags: test-image
           build-args: "GIT_COMMIT=${{ github.sha }}"
           secret-files: BUILD_KEY=/tmp/build_key.json
           provenance: false
@@ -164,7 +164,7 @@ jobs:
       - if: ${{ inputs.test_dagster }}
         name: Test Dagster Docker image
         run: |
-          docker run -p 8080:8080 -d --env 'TZ=Europe/Brussels' --name test_container ${{ env.IMAGE_NAME }}/branch/${{ github.head_ref }}:test \
+          docker run -p 8080:8080 -d --env 'TZ=Europe/Brussels' --name test_container test-image \
               dagster api grpc -h 0.0.0.0 -p 8080 --python-file "/dagster/${{ steps.find_repo_file.outputs.REPOSITORY_PY_LOCATION }}"
           sleep 5
           wget -O/tmp/grpc_health_probe -q https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.11/grpc_health_probe-linux-amd64

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -125,7 +125,7 @@ jobs:
             }
 
       - name: Set up Docker Buildx 
-        uses: docker/setup-buildx-action@v2.10.0
+        uses: docker/setup-buildx-action@v3
         with:
           driver: ${{ inputs.docker_buildx_driver }}
 
@@ -142,7 +142,7 @@ jobs:
 
       - if: ${{ inputs.test_dagster }}
         name: Build docker image
-        uses: docker/build-push-action@v4.1.1
+        uses: docker/build-push-action@v5
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         with:
@@ -175,7 +175,7 @@ jobs:
       - name: Push docker image
         # if either a tag isn't provided, or if the run is scheduled (using automatic docker re-builds) for security
         if: ${{ !startsWith(github.ref, 'refs/tags/') || github.event_name == 'scheduled' }}
-        uses: docker/build-push-action@v4.1.1
+        uses: docker/build-push-action@v5
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         with:

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -125,7 +125,7 @@ jobs:
             }
 
       - name: Set up Docker Buildx 
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v2.10.0
         with:
           driver: ${{ inputs.docker_buildx_driver }}
 
@@ -142,7 +142,7 @@ jobs:
 
       - if: ${{ inputs.test_dagster }}
         name: Build docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v4.1.1
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         with:
@@ -174,7 +174,7 @@ jobs:
       - name: Push docker image
         # if either a tag isn't provided, or if the run is scheduled (using automatic docker re-builds) for security
         if: ${{ !startsWith(github.ref, 'refs/tags/') || github.event_name == 'scheduled' }}
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v4.1.1
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         with:

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -85,6 +85,7 @@ jobs:
           path: ${{ inputs.artifacts_path }}
 
       - name: Set up Docker Buildx
+        id: buildx-setup
         uses: docker/setup-buildx-action@v2.10.0
         with:
           driver: ${{ inputs.docker_buildx_driver }}
@@ -100,6 +101,12 @@ jobs:
       - name: Use glcoud CLI to configure-docker auth
         run: gcloud auth configure-docker eu.gcr.io,europe-west4-docker.pkg.dev
 
+      - name: print driver
+        run: |
+         echo ${{ inputs.docker_buildx_driver }}
+         echo ${{ steps.buildx-setup.driver }}
+         echo ${{ steps.buildx-setup.driver == 'docker-container' && 'type=gha,mode=max' || 's' }}
+
       - if: ${{ inputs.test_dagster }}
         name: Build docker image
         uses: docker/build-push-action@v4.1.1
@@ -114,7 +121,7 @@ jobs:
           secret-files: BUILD_KEY=/tmp/build_key.json
           provenance: false
           cache-from: type=gha
-          cache-to: ${{ inputs.docker_buildx_driver == 'docker-container' && 'type=gha,mode=max' || '' }}
+          cache-to: ${{ steps.buildx-setup.driver == 'docker-container' && 'type=gha,mode=max' || 's' }}
 
       - if: ${{ inputs.test_dagster }}
         name: Find repository.py file

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -65,7 +65,7 @@ jobs:
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     steps:
-      - name: Clear some space  # https://github.com/apache/flink/blob/master/tools/azure-pipelines/free_disk_space.sh
+      - name: Clear some space  # https://github.com/apache/flink/blob/master/tools/azure-pipelines/free_disk_space.sh 
         if: ${{ inputs.clear_space }}
         run: |
           df -h
@@ -73,10 +73,10 @@ jobs:
           # sudo apt remove -y '^llvm-.*'
           # sudo apt remove -y '^mongodb-.*'
           # sudo apt remove -y '^mysql-.*'
-          sudo apt remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
-          sudo apt autoremove -y
-          sudo apt clean
-          df -h
+          # sudo apt remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
+          # sudo apt autoremove -y
+          # sudo apt clean
+          # df -h
           # echo "Removing large directories"
           # sudo rm -rf /usr/share/dotnet/
           # sudo rm -rf /usr/local/graalvm/
@@ -85,6 +85,8 @@ jobs:
           # sudo rm -rf /usr/local/share/chromium
           # sudo rm -rf /usr/local/lib/android
           # sudo rm -rf /usr/local/lib/node_modules
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           df -h
 
       - name: Checkout


### PR DESCRIPTION
# Problem 1: Docker layer caching using `gha` incompatible with `driver: docker`
`active-learning` builds a large docker image with the `docker` buildx driver. This driver is incompatible with the `gha` cache.

Therefore, the docker layers are not cached. This causes slow iteration times for developers working with a `dev-env`.

The choices are: 

Docker with buildx driver `docker-container`:
* can use `gha` cache
* is slow, because it needs to load the image into docker after building it

Docker with buildx driver `docker`:
* cannot use `gha` cache, UNLESS the new `containerd-snapshotter` is turned on (only supported by latest docker)

Other options are:
* use a registry as cache (potentially slower)
* upload the test image to a registry and download it again (can be faster than `load: true`) (!)

I chose to use the `containerd-snapshotter`.

Tested here: https://github.com/20treeAI/active-learning/actions/runs/7820825500/job/21336391746

Sources:
* https://github.com/docker/setup-buildx-action/issues/257
* https://github.com/kwikwag/issue-docker-gha-load-very-slow/blob/main/.github/workflows/jobs.yaml

# Problem 2: Github runner disk space
The Github runners have very limit free space (around 14GB). Building a 6 GB docker image can cause this space to run out.

Potential fixes:
* don't use caches for poetry & pip, clean up apt (best practices for Dockerfiles)
* don't create tarballs of the docker if not necessary
* clean up space on the runner (!), however, this can be slow (and it is unnecessary if the Docker does not need to be fully rebuilt
* use a GCP runner with more disk space

I added an option to clear some space which we can enable in `active-learning`.

Sources:
* https://github.com/apache/flink/blob/master/tools/azure-pipelines/free_disk_space.sh
* https://github.com/docker/build-push-action/issues/238
* https://github.com/actions/runner-images/issues/709#issuecomment-612569242


I've tested this for 2 repos: `active-learning` (uses docker driver) and `risk-score` (uses `docker-container` driver)

# Other changes

* disabled the `push` for the test image, since it is only used locally.