### PR TITLE
fix: SSH auth

### DIFF
--- a/.github/workflows/dagster.yml
+++ b/.github/workflows/dagster.yml
@@ -75,7 +75,7 @@ jobs:
     # only run on synchronize PR event, meaning something has been pushed to the PR branch
     if: github.event_name == 'push' || contains(fromJSON('["opened", "synchronize", "reopened", "push"]'), github.event.action) || (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'dev-env')
     # query our reusable docker build and push workflow
-    uses: 20treeAI/github-workflows/.github/workflows/docker_build_push.yml@main
+    uses: 20treeAI/github-workflows/.github/workflows/docker_build_push.yml@fix/space
     with:
       image_name: ${{ inputs.image_name }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/dagster.yml
+++ b/.github/workflows/dagster.yml
@@ -75,7 +75,7 @@ jobs:
     # only run on synchronize PR event, meaning something has been pushed to the PR branch
     if: github.event_name == 'push' || contains(fromJSON('["opened", "synchronize", "reopened", "push"]'), github.event.action) || (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'dev-env')
     # query our reusable docker build and push workflow
-    uses: 20treeAI/github-workflows/.github/workflows/docker_build_push.yml@fix/space
+    uses: 20treeAI/github-workflows/.github/workflows/docker_build_push.yml@main
     with:
       image_name: ${{ inputs.image_name }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -62,6 +62,7 @@ jobs:
   docker-build-test-push:
     env:
       IMAGE_NAME: europe-west4-docker.pkg.dev/${{ inputs.gcp_project }}/image/${{ inputs.image_name }}
+      SSH_AUTH_SOCK: /tmp/ssh_agent.sock
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     steps:
@@ -94,12 +95,10 @@ jobs:
 
       - name: Setup SSH Keys and known_hosts
         shell: bash -l {0}
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         run: |
           mkdir -p ~/.ssh
           ssh-keyscan github.com >> ~/.ssh/known_hosts
-          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+          ssh-agent -a ${{ env.SSH_AUTH_SOCK }}> /dev/null
           ssh-add - <<< "${{ secrets.SSH_KEY }}"
 
       - name: Import build key
@@ -143,14 +142,12 @@ jobs:
       - if: ${{ inputs.test_dagster }}
         name: Build docker image
         uses: docker/build-push-action@v5
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         with:
           context: .
           load: ${{ inputs.docker_buildx_driver == 'docker-container' && true || false }}
           push: false
           tags: test-image
-          ssh: default
+          ssh: ${{ env.SSH_AUTH_SOCK }}
           build-args: "GIT_COMMIT=${{ github.sha }}"
           secret-files: BUILD_KEY=/tmp/build_key.json
           provenance: false
@@ -176,12 +173,10 @@ jobs:
         # if either a tag isn't provided, or if the run is scheduled (using automatic docker re-builds) for security
         if: ${{ !startsWith(github.ref, 'refs/tags/') || github.event_name == 'scheduled' }}
         uses: docker/build-push-action@v5
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         with:
           context: .
           push: ${{ !inputs.skip_image_push }}
-          ssh: default
+          ssh: ${{ env.SSH_AUTH_SOCK }}
           build-args: "GIT_COMMIT=${{ github.sha }}"
           secret-files: BUILD_KEY=/tmp/build_key.json
           tags: |


### PR DESCRIPTION
`active-learning` exhibited a gnarly issue after https://github.com/20treeAI/github-workflows/pull/96 went in:

```
 ERROR: failed to solve: process "/bin/sh -c poetry install --only main -vvv --no-cache" did not complete successfully: listen unix /home/runner/setup-docker-action-ea9b13b3-db6b-4c53-bdf1-19bf02ffdc0a/data/tmp/.buildkit-ssh-sock2385055271/ssh_auth_sock: bind: invalid argument
Error: buildx failed with: ERROR: failed to solve: process "/bin/sh -c poetry install --only main -vvv --no-cache" did not complete successfully: listen unix /home/runner/setup-docker-action-ea9b13b3-db6b-4c53-bdf1-19bf02ffdc0a/data/tmp/.buildkit-ssh-sock2385055271/ssh_auth_sock: bind: invalid argument
```

This fixes that issue. I think the `default` changed for the `ssh` parameter in docker with the bumped version of the build-push-action, or by the bump of docker engine from 24 to 25.

https://github.com/20treeAI/active-learning/actions/runs/7844051874/job/21405610556?pr=193


Tested:
risk-score (docker-container driver): https://github.com/20treeAI/risk_score/actions/runs/7846142135/job/21412151645?pr=447
active-learning (docker driver): https://github.com/20treeAI/active-learning/actions/runs/7846034762/job/21411795908