### PR TITLE
fix: internal consistency

### DIFF
--- a/.github/workflows/dagster-scheduled-workflow.yml
+++ b/.github/workflows/dagster-scheduled-workflow.yml
@@ -60,7 +60,7 @@ on:
 jobs:
   run-docker-workflow:
     # query our reusable docker build and push workflow
-    uses: 20treeAI/github-workflows/.github/workflows/docker_build_push.yml@main
+    uses: ./.github/workflows/docker_build_push.yml
     with:
       image_name: ${{ inputs.image_name }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/dagster.yml
+++ b/.github/workflows/dagster.yml
@@ -75,7 +75,7 @@ jobs:
     # only run on synchronize PR event, meaning something has been pushed to the PR branch
     if: github.event_name == 'push' || contains(fromJSON('["opened", "synchronize", "reopened", "push"]'), github.event.action) || (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'dev-env')
     # query our reusable docker build and push workflow
-    uses: 20treeAI/github-workflows/.github/workflows/docker_build_push.yml@${{ github.head_ref }}
+    uses: 20treeAI/github-workflows/.github/workflows/docker_build_push.yml@${{ github.ref }}
     with:
       image_name: ${{ inputs.image_name }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/dagster.yml
+++ b/.github/workflows/dagster.yml
@@ -75,7 +75,7 @@ jobs:
     # only run on synchronize PR event, meaning something has been pushed to the PR branch
     if: github.event_name == 'push' || contains(fromJSON('["opened", "synchronize", "reopened", "push"]'), github.event.action) || (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'dev-env')
     # query our reusable docker build and push workflow
-    uses: 20treeAI/github-workflows/.github/workflows/docker_build_push.yml@main
+    uses: 20treeAI/github-workflows/.github/workflows/docker_build_push.yml@${{ github.head_ref }}
     with:
       image_name: ${{ inputs.image_name }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/dagster.yml
+++ b/.github/workflows/dagster.yml
@@ -75,7 +75,7 @@ jobs:
     # only run on synchronize PR event, meaning something has been pushed to the PR branch
     if: github.event_name == 'push' || contains(fromJSON('["opened", "synchronize", "reopened", "push"]'), github.event.action) || (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'dev-env')
     # query our reusable docker build and push workflow
-    uses: 20treeAI/github-workflows/.github/workflows/docker_build_push.yml@${{ github.ref }}
+    uses: ./.github/workflows/docker_build_push.yml
     with:
       image_name: ${{ inputs.image_name }}
       branch: ${{ inputs.branch }}


### PR DESCRIPTION
The inclusion always pointed to main, this causes hard-to-debug issues when pointing to a tag (since you expect to use all jobs from that tag).

Reusable workflows support local links! https://docs.github.com/en/actions/using-workflows/reusing-workflows#calling-a-reusable-workflow

@alexberndt you'll like this.