### PR TITLE
fix: invalidate venv cache on pyproject.toml change

### DIFF
--- a/.github/workflows/python_gdal_ci.yml
+++ b/.github/workflows/python_gdal_ci.yml
@@ -123,7 +123,7 @@ jobs:
         id: conda-env-cache
         with:
           path: /home/runner/miniconda3/envs/ci-env
-          key: conda-${{ env.MONTH }}-${{ hashFiles('env.yml') }}-${{ hashFiles('poetry.lock') }}
+          key: conda-${{ env.MONTH }}-${{ hashFiles('env.yml') }}-${{ hashFiles('poetry.lock') }}-${{ hashFiles('pyproject.toml') }}
 
         # Only install conda packages if the cache is invalidated
       - name: Install conda packages

--- a/.github/workflows/python_library_ci.yml
+++ b/.github/workflows/python_library_ci.yml
@@ -98,7 +98,7 @@ jobs:
         id: conda-env-cache
         with:
           path: /home/runner/miniconda3/envs/ci-env
-          key: conda-${{ env.MONTH }}-${{ hashFiles('env.yml') }}-${{ hashFiles('poetry.lock') }}
+          key: conda-${{ env.MONTH }}-${{ hashFiles('env.yml') }}-${{ hashFiles('poetry.lock') }}-${{ hashFiles('pyproject.toml') }}
 
       # Only install conda packages if the cache is invalidated
       - name: Install conda packages


### PR DESCRIPTION
* not doing this can cause issues with the version checks we have in place