### PR TITLE
feat: switch to codeServerArgs for Dagster to support dynamic reloading

### DIFF
--- a/.github/workflows/dagster.yml
+++ b/.github/workflows/dagster.yml
@@ -176,7 +176,7 @@ jobs:
                     repository: ${{ format('europe-west4-docker.pkg.dev/{0}/image/{1}', inputs.gcp_project, inputs.image_name) }}
                     tag: ${{ format('pr-{0}', github.event.number) }}
                     pullPolicy: Always
-                  dagsterApiGrpcArgs:
+                  codeServerArgs:
                     - "--python-file"
                     - "/dagster/${{ steps.find_repo_file.outputs.REPOSITORY_PY_LOCATION }}"
                   port: 3030

--- a/.github/workflows/dagster.yml
+++ b/.github/workflows/dagster.yml
@@ -114,7 +114,7 @@ jobs:
           kubectl rollout status deployment -n dagster dagster-dagster-user-deployments-${{ inputs.image_name }} -w --timeout=10m && echo "Deployment completed" || ( kubectl logs -n dagster -l deployment=${{ inputs.image_name }} && exit 1 )
 
   deploy-dev-env-to-gke:
-    if: github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'dev-env'
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'dev-env')
     runs-on: ubuntu-latest
     needs: run-docker-workflow
     steps:
@@ -133,11 +133,22 @@ jobs:
           cluster_name: ${{ inputs.stage_cluster_name }}
           location: ${{ inputs.gcp_location }}
 
+      - name: Update dev-env
+        if: github.event.action != 'labeled'
+        env:
+          DEPLOYMENT_NAME: ${{ format('{0}-pr-{1}-dagster-user-deployments-{0}-pr-{1}', inputs.image_name, github.event.number) }}
+          DEPLOYMENT_LABEL: ${{ format('{0}-pr-{1}', inputs.image_name, github.event.number) }}
+        run: |
+          kubectl rollout restart deployment -n dagster $DEPLOYMENT_NAME
+          kubectl rollout status deployment -n dagster $DEPLOYMENT_NAME -w --timeout=10m && echo "Deployment completed" || ( kubectl logs -n dagster -l deployment=$DEPLOYMENT_LABEL && exit 1 )
+
       - name: Find repository.py file for helm deployment
+        if: github.event.action == 'labeled' && github.event.label.name == 'dev-env'
         id: find_repo_file
         run: echo "REPOSITORY_PY_LOCATION=$(find . -maxdepth 2 -name repository.py)" >> $GITHUB_OUTPUT
 
       - name: Install dagster helm chart for developer environment
+        if: github.event.action == 'labeled' && github.event.label.name == 'dev-env'
         uses: vimeda/helm@v1.7.0
         with:
           helm: helm3


### PR DESCRIPTION
In dev envs changes are usually deployed in quick iterations. This change switches to dagster code-server to support dynamic reloading of the code server/user repo. 

Related issue: https://github.com/dagster-io/dagster/issues/12581
Support added in: https://github.com/dagster-io/dagster/pull/14377