### PR TITLE
Add a context input to allow for building multiple services

### DIFF
--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -46,7 +46,7 @@ on:
         required: false
         default: false
         type: boolean
-      context:
+      docker_build_context:
         description: "Custom context. Used for repositories that contain multiple buildable services."
         required: false
         default: "."
@@ -148,7 +148,7 @@ jobs:
         name: Build docker image
         uses: docker/build-push-action@v5
         with:
-          context: ${{ inputs.context }}
+          context: ${{ inputs.docker_build_context }}
           load: ${{ inputs.docker_buildx_driver == 'docker-container' && true || false }}
           push: false
           tags: ${{ env.IMAGE_NAME }}:${{ github.sha }}

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -46,7 +46,11 @@ on:
         required: false
         default: false
         type: boolean
-
+      context:
+        description: "Custom context. Used for repositories that contain multiple buildable services."
+        required: false
+        default: "."
+        type: string
     secrets:
       SSH_KEY:
         description: 'SSH key used to access private repos during the build'
@@ -144,7 +148,7 @@ jobs:
         name: Build docker image
         uses: docker/build-push-action@v5
         with:
-          context: .
+          context: ${{ inputs.context }}
           load: ${{ inputs.docker_buildx_driver == 'docker-container' && true || false }}
           push: false
           tags: ${{ env.IMAGE_NAME }}:${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This [workflow](./.github/workflows/docker_build_push.yml) will build and push a
 | artifacts_path        | Path to use for the artifacts object                                          | string  | `build/`         |  false   |
 | test_dagster          | whether or not to test docker image for dagster compatibility                 | boolean | false            |  false   |
 | skip_image_push       | whether to skip image push (so that you can test image build without pushing) | boolean | false            |  false   |
-| context       | custom build context (used if there are multiple buildable services in one repository) | string | false            |  '.'   |
+| docker_build_context       | custom build context (used if there are multiple buildable services in one repository) | string | false            |  '.'   |
 
 #### Input Secrets
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ This [workflow](./.github/workflows/docker_build_push.yml) will build and push a
 | artifacts_path        | Path to use for the artifacts object                                          | string  | `build/`         |  false   |
 | test_dagster          | whether or not to test docker image for dagster compatibility                 | boolean | false            |  false   |
 | skip_image_push       | whether to skip image push (so that you can test image build without pushing) | boolean | false            |  false   |
+| context       | custom build context (used if there are multiple buildable services in one repository) | string | false            |  '.'   |
 
 #### Input Secrets
 


### PR DESCRIPTION
Add an input to the shared workflow that allows for passing a non-standard context (not `.`) to Docker build workflows