### PR TITLE
custom package dir

### DIFF
--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -179,7 +179,7 @@ jobs:
         if: ${{ !startsWith(github.ref, 'refs/tags/') || github.event_name == 'scheduled' }}
         uses: docker/build-push-action@v5
         with:
-          context: .
+          context: ${{ inputs.docker_build_context }}
           push: ${{ !inputs.skip_image_push }}
           ssh: ${{ inputs.docker_buildx_driver == 'docker-container' && env.SSH_DEFAULT || env.SSH_AUTH_SOCK }}
           build-args: "GIT_COMMIT=${{ github.sha }}"

--- a/.github/workflows/yarn_build_test.yml
+++ b/.github/workflows/yarn_build_test.yml
@@ -39,13 +39,13 @@ jobs:
       - name: Install dependencies
         uses: borales/actions-yarn@v4.2.0
         with:
-          path: ${{ inputs.package_dir }}
+          dir: ${{ inputs.package_dir }}
           cmd: install # will run `yarn install` command
 
       - name: Build application
         uses: borales/actions-yarn@v4.2.0
         with:
-          path: ${{ inputs.package_dir }}
+          dir: ${{ inputs.package_dir }}
           cmd: build # will run `yarn build` command
         env: 
           REACT_APP_MAPBOX_TOKEN_STAGE: ${{ secrets.REACT_APP_MAPBOX_TOKEN_STAGE }}
@@ -54,7 +54,7 @@ jobs:
       - name: Test application
         uses: borales/actions-yarn@v4.2.0
         with:
-          path: ${{ inputs.package_dir }}
+          dir: ${{ inputs.package_dir }}
           cmd: test # will run `yarn test` command
 
       - name: Upload artifacts

--- a/.github/workflows/yarn_build_test.yml
+++ b/.github/workflows/yarn_build_test.yml
@@ -61,5 +61,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: build-artifacts
-          path: build/
+          path: ${{ format('{0}/{1}', inputs.package_dir, 'build/')}}
           retention-days: 1

--- a/.github/workflows/yarn_build_test.yml
+++ b/.github/workflows/yarn_build_test.yml
@@ -5,8 +5,8 @@ on:
   workflow_call:
     inputs:
       package_dir:
-        description: 'Path to the directory containing the app. Defaults to /'
-        default: '/'
+        description: 'Path to the directory containing the app. Defaults to .'
+        default: '.'
         required: false
         type: string
     secrets:

--- a/.github/workflows/yarn_build_test.yml
+++ b/.github/workflows/yarn_build_test.yml
@@ -3,6 +3,12 @@ name: yarn - build and test
 # https://docs.github.com/en/actions/using-workflows/reusing-workflows#creating-a-reusable-workflow
 on:
   workflow_call:
+    inputs:
+      package_dir:
+        description: 'Path to the directory containing the app. Defaults to /'
+        default: '/'
+        required: false
+        type: string
     secrets:
       REACT_APP_MAPBOX_TOKEN_STAGE:
         description: 'staging mapbox token to be passed to the yarn build'
@@ -33,11 +39,13 @@ jobs:
       - name: Install dependencies
         uses: borales/actions-yarn@v4.2.0
         with:
+          path: ${{ inputs.package_dir }}
           cmd: install # will run `yarn install` command
 
       - name: Build application
         uses: borales/actions-yarn@v4.2.0
         with:
+          path: ${{ inputs.package_dir }}
           cmd: build # will run `yarn build` command
         env: 
           REACT_APP_MAPBOX_TOKEN_STAGE: ${{ secrets.REACT_APP_MAPBOX_TOKEN_STAGE }}
@@ -46,6 +54,7 @@ jobs:
       - name: Test application
         uses: borales/actions-yarn@v4.2.0
         with:
+          path: ${{ inputs.package_dir }}
           cmd: test # will run `yarn test` command
 
       - name: Upload artifacts

--- a/examples/yarn_build_test.yml
+++ b/examples/yarn_build_test.yml
@@ -14,6 +14,9 @@ jobs:
   # builds and tests the app with yarn
   yarn_build_test:
     uses: 20treeAI/github-workflows/.github/workflows/yarn_build_test.yml@main
+    with:
+      # optional, if your js app isn't in at the top level of your repo
+      package_dir: ./client
     secrets:
       # this one is optional, but must be created ahead of time in the repo
       REACT_APP_MAPBOX_TOKEN_STAGE: ${{ secrets.REACT_APP_MAPBOX_TOKEN_STAGE }}


### PR DESCRIPTION
Optional config value to point to the package directory, defaults to `.`. Needed to support Corgi, since it's a monorepo and the frontend is located at `./client/`

It also modifies the `docker_build_push` workflow to use the parameterised context variable for the `push docker image` step. 