### PR TITLE
Add DAGSTER_ENV = test env var in Python CI

### DIFF
--- a/.github/workflows/python_gdal_ci.yml
+++ b/.github/workflows/python_gdal_ci.yml
@@ -91,6 +91,7 @@ jobs:
     env:
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcloud_key.json
       SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+      DAGSTER_ENV: test
     defaults:
       run:
         shell: bash -el {0}

--- a/.github/workflows/python_library_ci.yml
+++ b/.github/workflows/python_library_ci.yml
@@ -59,6 +59,7 @@ jobs:
     env:
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcloud_key.json
       SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+      DAGSTER_ENV: test
     defaults:
       run:
         shell: bash -el {0}


### PR DESCRIPTION
Adds the `DAGSTER_ENV=test` environment variable to the base Python and GDAL CI workflows. This is needed so that CI tests behave accordingly when being tested in the CI.

Original request from @orenstory  [here](https://20treeai.slack.com/archives/C84DWS72S/p1710869970457739)
